### PR TITLE
Implement full-stack functionality and mock backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,405 @@
+# Полная документация AI Helper платформы
+
+## ️ Текущая архитектура
+
+### Технологический стек
+
+- **Frontend**: Next.js 15 (App Router)
+- **Styling**: Tailwind CSS v4 + shadcn/ui компоненты
+- **Типизация**: TypeScript
+- **Шрифты**: Geist Sans, Manrope
+- **Аналитика**: Vercel Analytics
+- **Серверные маршруты**: Next.js Route Handlers (`app/api/*`) с in-memory БД
+
+### Быстрый старт
+
+1. Установите зависимости: `pnpm install`
+2. Запустите dev-сервер: `pnpm dev`
+3. По умолчанию доступны демо-учётные данные `demo@aihelper.dev` / `demo1234`
+4. Все API работают локально и не требуют внешних ключей
+
+## Проверка функциональности (end-to-end сценарии)
+
+Ниже приведены ключевые пользовательские сценарии, которые можно проверить сразу после запуска dev-сервера.
+
+### Аутентификация и сессии
+
+1. Перейдите на `/register`, создайте нового пользователя и убедитесь, что после сабмита появляется активная сессия (кнопка «Выйти» на страницах и доступ к защищённым маршрутам).
+2. Разлогиньтесь через кнопку «Выйти» и подтвердите, что защищённые страницы (`/dashboard`, `/content-generation` и т.д.) теперь отображают CTA для входа.
+3. Используйте форму восстановления пароля на `/forgot-password`, чтобы получить временный токен (он отображается в UI) и завершите процесс на `/reset-password`.
+
+### Управление проектами
+
+1. Откройте `/projects/new`, заполните форму и отправьте — проект появится на дэшборде и в списке последних проектов.
+2. Используя полученный идентификатор, можно протестировать обновление/удаление через API (`PUT/DELETE /api/projects/:id`) — состояние мгновенно меняется в UI после обновления страницы.
+
+### AI-инструменты
+
+1. `/content-generation` — отправьте тему, стиль и длину. Ответ появится в панели результатов и будет сохранён в истории AI-запросов.
+2. `/text-analysis` — вставьте текст и выполните анализ. Метрики читаемости, уникальности и рекомендации выводятся рядом с исходным текстом.
+3. `/chatbot` — ведите диалог и посмотрите, как история сообщений сохраняется между обновлениями страницы.
+4. `/marketing` — сформируйте идеи для выбранных каналов. История идей хранится per-user и отображается в таблице.
+5. `/image-generation` и `/voice-assistant` демонстрируют генерацию изображений и расшифровку аудио с mock-ответами и проверкой квоты.
+
+### Управление моделями и файлами
+
+1. `/ai-models` позволяет добавлять/удалять подключения к поставщикам. Валидация формы предотвращает отправку неполных данных.
+2. `/settings` содержит форму профиля и загрузчик файлов — после отправки файл появляется в разделе «Последние загрузки».
+
+### Дэшборд и аналитика
+
+1. `/dashboard` агрегирует статистику из in-memory базы: количество проектов, историю AI-запросов и usage-квоты.
+2. Кнопка обновления в шапке инициирует повторный запрос к `/api/dashboard`, демонстрируя реактивность UI.
+
+### Структура проекта
+
+```plaintext
+app/
+├── layout.tsx                 # Корневой layout с метаданными
+├── page.tsx                   # Главная страница
+├── globals.css                # Глобальные стили и дизайн-система
+├── about/page.tsx             # О компании
+├── ai-models/page.tsx         # Управление AI моделями
+├── chatbot/page.tsx           # Чат-бот интерфейс
+├── contact/page.tsx           # Контактная форма
+├── content-generation/page.tsx # Генерация контента
+├── dashboard/page.tsx         # Пользовательская панель
+├── faq/page.tsx              # Часто задаваемые вопросы
+├── forgot-password/page.tsx   # Восстановление пароля
+├── image-generation/page.tsx  # Генерация изображений
+├── login/page.tsx            # Авторизация
+├── marketing/page.tsx        # Маркетинговые инструменты
+├── privacy/page.tsx          # Политика конфиденциальности
+├── projects/new/page.tsx     # Создание проектов
+├── register/page.tsx         # Регистрация
+├── settings/page.tsx         # Настройки пользователя
+├── support/page.tsx          # Техподдержка
+├── terms/page.tsx           # Условия использования
+├── text-analysis/page.tsx    # Анализ текста
+└── voice-assistant/page.tsx  # Голосовой помощник
+
+components/
+├── ui/                       # shadcn/ui компоненты (50+ компонентов)
+└── theme-provider.tsx        # Провайдер темы
+```
+
+## Дизайн-система
+
+### Цветовая палитра
+
+- **Основной фон**: Чистый черный (`#000000`)
+- **Текст**: Белый (`#ffffff`)
+- **Карточки**: Темно-серый (`#111111`)
+- **Границы**: Серый (`#333333`)
+- **Акценты**: Белые кнопки с черным текстом
+
+### Типографика
+
+- **Основной шрифт**: Geist Sans
+- **Дополнительный**: Manrope
+- **Размеры**: От 6xl до 8xl для заголовков
+- **Градиентный текст**: Белый → серый
+
+### UI компоненты
+
+- 50+ готовых shadcn/ui компонентов
+- Современный темный дизайн
+- Закругленные углы (0.75rem)
+- Анимации при наведении
+- Мобильная адаптивность
+
+## Реализованные функции
+
+### 1. Главная страница
+
+- **Статус**: ✅ Полностью реализована
+- **Функции**: Hero-секция, список функций, CTA, footer
+- **Особенности**: Адаптивная навигация, мобильное меню
+
+### 2. Аутентификация
+
+- **Страницы**: Вход, регистрация, восстановление пароля
+- **Статус**: ✅ Интегрирована с серверными маршрутами `/api/auth/*`
+- **Формы**: Клиентская валидация, обработка ошибок, создание сессии через HttpOnly cookie
+
+### 3. AI инструменты (Frontend UI)
+
+#### Генерация контента
+
+- Генерация текста через `/api/ai/content/generate`
+- Поддержка выбора формата, тона и длины
+- Копирование и выгрузка готового текста
+
+#### Анализ текста
+
+- Отправка текстов на `/api/ai/text/analyze`
+- Отображение метрик читабельности, количества слов, предложений и уникальных слов
+- Персональные рекомендации по улучшению
+
+#### Чат-бот
+
+- Общение с серверным `/api/ai/chat/message`
+- История диалогов сохраняется в памяти на пользователя
+- Отображение статуса набора сообщения
+
+#### Генерация изображений
+
+- Форма для промптов
+- Настройки стиля и размера
+- Галерея результатов
+
+#### Голосовой помощник
+
+- Демонстрация распознавания речи через `/api/ai/voice/transcribe`
+- Проверка наличия авторизации перед отправкой аудио
+- Управление режимами записи и обработки
+
+#### Маркетинговые инструменты
+
+- Генерация идей по бизнесу, аудитории и целям через `/api/ai/marketing/ideas`
+- Сохранение истории предложений
+- Аналитический дэшборд с фильтрами по каналам
+
+### 4. Управление AI моделями
+
+- **Статус**: ✅ Поддерживаются локальные и внешние подключения
+- **Функции**:
+  - Регистрация моделей через `/api/ai/models`
+  - Управление активностью подключений и удаление моделей
+  - Демонстрация доступных локальных LLM (Llama)
+  - Отображение статуса провайдеров (OpenAI, Anthropic, Google, Groq, Ollama)
+
+### 5. Пользовательская панель
+
+- **Статус**: ✅ Получает данные из `/api/dashboard`
+- **Функции**: Статистика использования, список проектов, история AI-запросов, быстрые действия
+- **Требования**: Авторизация (HttpOnly сессия)
+
+### 6. Информационные страницы
+
+- **Статус**: ✅ Готовы
+- **Страницы**: О нас, FAQ, поддержка, контакты, правовые
+
+## Серверная реализация
+
+Текущая версия использует in-memory хранилище (см. `lib/server/database.ts`) и набор Route Handlers в `app/api`. Ниже приведены ключевые эндпоинты и структуры данных.
+
+### 1. Система аутентификации
+
+```typescript
+// Требуемые API endpoints
+POST /api/auth/register
+POST /api/auth/login  
+POST /api/auth/logout
+POST /api/auth/forgot-password
+POST /api/auth/reset-password
+GET  /api/auth/me
+```
+
+**База данных - Таблица Users:**
+
+```sql
+CREATE TABLE users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  avatar_url TEXT,
+  subscription_plan VARCHAR(50) DEFAULT 'free',
+  subscription_expires_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### 2. AI модели и интеграции
+
+```typescript
+// API endpoints для AI
+POST /api/ai/content/generate
+POST /api/ai/text/analyze
+POST /api/ai/image/generate
+POST /api/ai/chat/message
+POST /api/ai/voice/transcribe
+POST /api/ai/marketing/ideas
+```
+
+**База данных - Таблица AI Models:**
+
+```sql
+CREATE TABLE ai_models (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  provider VARCHAR(100) NOT NULL, -- 'openai', 'anthropic', 'local_llama'
+  model_name VARCHAR(255) NOT NULL,
+  api_key TEXT, -- зашифрованный
+  endpoint_url TEXT, -- для локальных моделей
+  parameters JSONB, -- температура, max_tokens и т.д.
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### 3. Система проектов
+
+```typescript
+// API endpoints
+GET    /api/projects
+POST   /api/projects
+GET    /api/projects/:id
+PUT    /api/projects/:id
+DELETE /api/projects/:id
+```
+
+**База данных - Таблица Projects:**
+
+```sql
+CREATE TABLE projects (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  name VARCHAR(255) NOT NULL,
+  description TEXT,
+  type VARCHAR(100) NOT NULL, -- 'content', 'chatbot', 'analysis'
+  settings JSONB,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### 4. История и результаты AI
+
+**База данных - Таблица AI Requests:**
+
+```sql
+CREATE TABLE ai_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  project_id UUID REFERENCES projects(id),
+  type VARCHAR(100) NOT NULL, -- 'content_generation', 'text_analysis'
+  input_data JSONB NOT NULL,
+  output_data JSONB,
+  model_used VARCHAR(255),
+  tokens_used INTEGER,
+  cost DECIMAL(10,4),
+  status VARCHAR(50) DEFAULT 'pending', -- 'pending', 'completed', 'failed'
+  error_message TEXT,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### 5. Файловое хранилище
+
+```typescript
+// API endpoints
+POST /api/files/upload
+GET  /api/files/:id
+DELETE /api/files/:id
+```
+
+**База данных - Таблица Files:**
+
+```sql
+CREATE TABLE files (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  filename VARCHAR(255) NOT NULL,
+  original_name VARCHAR(255) NOT NULL,
+  mime_type VARCHAR(100) NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  storage_path TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### 6. Система подписок и биллинга
+
+**База данных - Таблица Subscriptions:**
+
+```sql
+CREATE TABLE subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  plan_name VARCHAR(100) NOT NULL,
+  status VARCHAR(50) NOT NULL, -- 'active', 'cancelled', 'expired'
+  current_period_start TIMESTAMP NOT NULL,
+  current_period_end TIMESTAMP NOT NULL,
+  stripe_subscription_id VARCHAR(255),
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE usage_limits (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  period_start TIMESTAMP NOT NULL,
+  period_end TIMESTAMP NOT NULL,
+  requests_used INTEGER DEFAULT 0,
+  requests_limit INTEGER NOT NULL,
+  tokens_used BIGINT DEFAULT 0,
+  tokens_limit BIGINT NOT NULL
+);
+```
+
+## Внешние интеграции
+
+### 1. AI провайдеры
+
+- **OpenAI API**: GPT-4, DALL-E, Whisper
+- **Anthropic**: Claude модели
+- **Google AI**: Gemini
+- **Groq**: Быстрые LLM
+- **Локальные модели**: Ollama для Llama
+
+### 2. Файловое хранилище
+
+- **AWS S3** или **Vercel Blob** для файлов
+- **CloudFront** для CDN
+
+### 3. Платежи
+
+- **Stripe** для обработки платежей
+- **Webhooks** для обновления подписок
+
+### 4. Мониторинг и аналитика
+
+- **Vercel Analytics** (уже подключен)
+- **Sentry** для отслеживания ошибок
+- **PostHog** для пользовательской аналитики
+
+## Рекомендуемая архитектура бэкенда
+
+### Технологии
+
+- **Runtime**: Node.js/Bun
+- **Framework**: Next.js API Routes или Fastify
+- **База данных**: PostgreSQL (Supabase/Neon)
+- **ORM**: Prisma или Drizzle
+- **Кэширование**: Redis (Upstash)
+- **Очереди**: Bull/BullMQ для AI задач
+
+### Структура API
+
+```plaintext
+api/
+├── auth/           # Аутентификация
+├── users/          # Управление пользователями  
+├── projects/       # CRUD проектов
+├── ai/            # AI интеграции
+│   ├── content/   # Генерация контента
+│   ├── text/      # Анализ текста
+│   ├── image/     # Генерация изображений
+│   ├── chat/      # Чат-бот
+│   └── voice/     # Голосовые функции
+├── files/         # Файловое хранилище
+├── billing/       # Подписки и платежи
+└── admin/         # Административные функции
+```
+
+### Безопасность
+
+- JWT токены для аутентификации
+- Rate limiting для API
+- Шифрование API ключей
+- CORS настройки
+- Input validation и sanitization
+
+Платформа готова к интеграции с бэкендом - все UI компоненты реализованы, дизайн-система настроена, остается только подключить реальные API и базу данных для полноценного функционирования.

--- a/app/ai-models/page.tsx
+++ b/app/ai-models/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { FormEvent, useEffect, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -9,34 +9,141 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Switch } from "@/components/ui/switch"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Brain, Server, Cloud, Settings, CheckCircle, Cpu, Zap, Globe, Shield, Download } from "lucide-react"
+import {
+  Brain,
+  Server,
+  Cloud,
+  Settings,
+  CheckCircle,
+  Cpu,
+  Zap,
+  Globe,
+  Shield,
+  Download,
+  Trash2,
+  Loader2,
+} from "lucide-react"
 import Link from "next/link"
+import { apiClient } from "@/lib/api-client"
+import { useAuthContext } from "@/components/providers/auth-context"
+
+type ModelRecord = {
+  id: string
+  provider: string
+  modelName: string
+  endpointUrl?: string
+  isActive: boolean
+  createdAt?: string
+}
+
+type FormState = {
+  provider: string
+  modelName: string
+  apiKey: string
+  endpointUrl: string
+}
+
+const LOCAL_MODELS = [
+  { name: "Llama 3.1 8B", status: "installed", size: "4.7GB", performance: "high" },
+  { name: "Llama 3.1 70B", status: "available", size: "39GB", performance: "ultra" },
+  { name: "Code Llama 7B", status: "installed", size: "3.8GB", performance: "medium" },
+]
 
 export default function AIModelsPage() {
-  const [localModels, setLocalModels] = useState([
-    { name: "Llama 3.1 8B", status: "installed", size: "4.7GB", performance: "high" },
-    { name: "Llama 3.1 70B", status: "available", size: "39GB", performance: "ultra" },
-    { name: "Code Llama 7B", status: "installed", size: "3.8GB", performance: "medium" },
-  ])
+  const { user } = useAuthContext()
+  const [form, setForm] = useState<FormState>({ provider: "openai", modelName: "gpt-4o-mini", apiKey: "", endpointUrl: "" })
+  const [models, setModels] = useState<ModelRecord[]>([])
+  const [activeConnections, setActiveConnections] = useState<Record<string, boolean>>({})
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
 
-  const [apiKeys, setApiKeys] = useState({
-    openai: "",
-    anthropic: "",
-    google: "",
-    cohere: "",
-    huggingface: "",
-  })
+  const loadModels = async () => {
+    if (!user) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const response = await apiClient.listModels()
+      const mapped: ModelRecord[] = response.models.map((model: any) => ({
+        id: model.id,
+        provider: model.provider,
+        modelName: model.modelName,
+        endpointUrl: model.endpointUrl,
+        isActive: model.isActive,
+        createdAt: model.createdAt,
+      }))
+      setModels(mapped)
+      const connections: Record<string, boolean> = {}
+      mapped.forEach((model) => {
+        connections[model.provider] = model.isActive
+      })
+      setActiveConnections(connections)
+    } catch (error) {
+      setError((error as Error).message)
+      setModels([])
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
-  const [activeConnections, setActiveConnections] = useState({
-    openai: true,
-    anthropic: false,
-    google: true,
-    local: true,
-  })
+  useEffect(() => {
+    if (user) {
+      loadModels()
+    }
+  }, [user])
+
+  const handleAddModel = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!user) {
+      setError("Авторизуйтесь, чтобы подключать модели")
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      await apiClient.addModel({
+        provider: form.provider,
+        modelName: form.modelName,
+        apiKey: form.apiKey || undefined,
+        endpointUrl: form.endpointUrl || undefined,
+        parameters: {},
+      })
+      setSuccess("Модель успешно сохранена")
+      setForm({ provider: form.provider, modelName: "", apiKey: "", endpointUrl: "" })
+      await loadModels()
+    } catch (error) {
+      setError((error as Error).message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      await apiClient.deleteModel(id)
+      await loadModels()
+    } catch (error) {
+      setError((error as Error).message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const activeProviders = useMemo(() => Object.keys(activeConnections).filter((key) => activeConnections[key]), [activeConnections])
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
+      {!user ? (
+        <div className="bg-muted/40 border-b border-border text-center text-xs uppercase tracking-wide py-2">
+          Авторизуйтесь, чтобы управлять подключениями AI моделей
+        </div>
+      ) : null}
+
       <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
           <div className="flex items-center gap-4">
@@ -57,11 +164,20 @@ export default function AIModelsPage() {
       </header>
 
       <div className="container mx-auto px-4 py-8">
+        {error ? (
+          <div className="mb-6 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+        {success ? (
+          <div className="mb-6 rounded-lg border border-primary/40 bg-primary/10 px-4 py-3 text-sm text-primary">{success}</div>
+        ) : null}
+
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-8">
             <h1 className="text-4xl font-bold mb-4 font-mono">Управление AI моделями</h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Подключайте локальные модели и внешние API для максимальной гибкости
+              Подключайте локальные модели и внешние API, контролируйте ключи доступа и параметры
             </p>
           </div>
 
@@ -88,13 +204,11 @@ export default function AIModelsPage() {
                     <Cpu className="h-5 w-5" />
                     Локальные LLM модели
                   </CardTitle>
-                  <CardDescription>
-                    Управляйте локально установленными моделями для максимальной приватности
-                  </CardDescription>
+                  <CardDescription>Управляйте локально установленными моделями</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  {localModels.map((model, index) => (
-                    <div key={index} className="flex items-center justify-between p-4 border rounded-lg">
+                  {LOCAL_MODELS.map((model) => (
+                    <div key={model.name} className="flex items-center justify-between p-4 border rounded-lg">
                       <div className="flex items-center gap-4">
                         <div className="p-2 bg-primary/10 rounded-lg">
                           <Brain className="h-6 w-6 text-primary" />
@@ -103,15 +217,7 @@ export default function AIModelsPage() {
                           <h3 className="font-semibold">{model.name}</h3>
                           <div className="flex items-center gap-2 text-sm text-muted-foreground">
                             <span>Размер: {model.size}</span>
-                            <Badge
-                              variant={
-                                model.performance === "ultra"
-                                  ? "default"
-                                  : model.performance === "high"
-                                    ? "secondary"
-                                    : "outline"
-                              }
-                            >
+                            <Badge variant="secondary" className="uppercase text-xs">
                               {model.performance === "ultra"
                                 ? "Ультра"
                                 : model.performance === "high"
@@ -124,26 +230,15 @@ export default function AIModelsPage() {
                       </div>
                       <div className="flex items-center gap-2">
                         {model.status === "installed" ? (
-                          <>
-                            <Badge variant="default" className="bg-green-100 text-green-800">
-                              <CheckCircle className="h-3 w-3 mr-1" />
-                              Установлена
-                            </Badge>
-                            <Button variant="outline" size="sm">
-                              Обновить
-                            </Button>
-                            <Button variant="destructive" size="sm">
-                              Удалить
-                            </Button>
-                          </>
+                          <Badge variant="default" className="bg-green-100 text-green-800">
+                            <CheckCircle className="h-3 w-3 mr-1" />
+                            Установлена
+                          </Badge>
                         ) : (
-                          <>
-                            <Badge variant="outline">
-                              <Download className="h-3 w-3 mr-1" />
-                              Доступна
-                            </Badge>
-                            <Button size="sm">Установить</Button>
-                          </>
+                          <Button size="sm">
+                            <Download className="h-4 w-4 mr-2" />
+                            Установить
+                          </Button>
                         )}
                       </div>
                     </div>
@@ -153,236 +248,165 @@ export default function AIModelsPage() {
 
               <Card>
                 <CardHeader>
-                  <CardTitle>Добавить новую модель</CardTitle>
-                  <CardDescription>
-                    Установите дополнительные модели из Hugging Face или других источников
-                  </CardDescription>
+                  <CardTitle>Добавить внешнюю модель</CardTitle>
+                  <CardDescription>Подключите модели OpenAI, Anthropic, Groq или кастомные endpoints</CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <Label>Название модели</Label>
-                      <Input placeholder="microsoft/DialoGPT-medium" />
+                <CardContent>
+                  <form className="grid gap-4" onSubmit={handleAddModel}>
+                    <div className="grid md:grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="provider">Провайдер</Label>
+                        <Select value={form.provider} onValueChange={(value) => setForm((prev) => ({ ...prev, provider: value }))}>
+                          <SelectTrigger id="provider">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="openai">OpenAI</SelectItem>
+                            <SelectItem value="anthropic">Anthropic</SelectItem>
+                            <SelectItem value="google">Google AI</SelectItem>
+                            <SelectItem value="groq">Groq</SelectItem>
+                            <SelectItem value="ollama">Ollama</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="modelName">Название модели</Label>
+                        <Input
+                          id="modelName"
+                          placeholder="Например: gpt-4o-mini"
+                          value={form.modelName}
+                          onChange={(event) => setForm((prev) => ({ ...prev, modelName: event.target.value }))}
+                          required
+                        />
+                      </div>
                     </div>
-                    <div className="space-y-2">
-                      <Label>Источник</Label>
-                      <Select>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Выберите источник" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="huggingface">Hugging Face</SelectItem>
-                          <SelectItem value="ollama">Ollama</SelectItem>
-                          <SelectItem value="local">Локальный файл</SelectItem>
-                        </SelectContent>
-                      </Select>
+                    <div className="grid md:grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="apiKey">API ключ</Label>
+                        <Input
+                          id="apiKey"
+                          type="password"
+                          placeholder="Введите или вставьте ключ"
+                          value={form.apiKey}
+                          onChange={(event) => setForm((prev) => ({ ...prev, apiKey: event.target.value }))}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="endpointUrl">Endpoint (опционально)</Label>
+                        <Input
+                          id="endpointUrl"
+                          placeholder="https://api.example.com/v1"
+                          value={form.endpointUrl}
+                          onChange={(event) => setForm((prev) => ({ ...prev, endpointUrl: event.target.value }))}
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <Button>
-                    <Download className="h-4 w-4 mr-2" />
-                    Установить модель
-                  </Button>
+                    <Button type="submit" disabled={isLoading}>
+                      {isLoading ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Сохраняем...
+                        </>
+                      ) : (
+                        "Сохранить модель"
+                      )}
+                    </Button>
+                  </form>
                 </CardContent>
               </Card>
             </TabsContent>
 
             <TabsContent value="api-connections" className="space-y-6">
-              <div className="grid md:grid-cols-2 gap-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Globe className="h-5 w-5" />
-                      OpenAI
-                    </CardTitle>
-                    <CardDescription>GPT-4, GPT-3.5, DALL-E и другие модели OpenAI</CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label>Активно</Label>
-                      <Switch
-                        checked={activeConnections.openai}
-                        onCheckedChange={(checked) => setActiveConnections({ ...activeConnections, openai: checked })}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>API ключ</Label>
-                      <Input
-                        type="password"
-                        placeholder="sk-..."
-                        value={apiKeys.openai}
-                        onChange={(e) => setApiKeys({ ...apiKeys, openai: e.target.value })}
-                      />
-                    </div>
-                    <Button variant="outline" size="sm">
-                      Тестировать подключение
-                    </Button>
-                  </CardContent>
-                </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Активные подключения</CardTitle>
+                  <CardDescription>Управляйте внешними моделями и API ключами</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {isLoading && models.length === 0 ? (
+                    <div className="text-sm text-muted-foreground">Загрузка подключений...</div>
+                  ) : models.length === 0 ? (
+                    <div className="text-sm text-muted-foreground">Пока нет подключённых моделей</div>
+                  ) : (
+                    models.map((model) => (
+                      <div key={model.id} className="border rounded-lg p-4 flex items-center justify-between">
+                        <div>
+                          <h3 className="font-semibold flex items-center gap-2">
+                            {model.modelName}
+                            {model.isActive ? (
+                              <Badge variant="outline" className="border-green-500 text-green-600">
+                                Активна
+                              </Badge>
+                            ) : null}
+                          </h3>
+                          <p className="text-sm text-muted-foreground">Провайдер: {model.provider}</p>
+                          {model.endpointUrl ? (
+                            <p className="text-xs text-muted-foreground mt-1">Endpoint: {model.endpointUrl}</p>
+                          ) : null}
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <Switch
+                            checked={model.isActive}
+                            onCheckedChange={(checked) =>
+                              setActiveConnections((prev) => ({ ...prev, [model.provider]: checked }))
+                            }
+                            aria-label="Активировать модель"
+                          />
+                          <Button variant="ghost" size="icon" onClick={() => handleDelete(model.id)}>
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </CardContent>
+              </Card>
 
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Brain className="h-5 w-5" />
-                      Anthropic
-                    </CardTitle>
-                    <CardDescription>Claude 3.5 Sonnet, Claude 3 Haiku и другие модели</CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label>Активно</Label>
-                      <Switch
-                        checked={activeConnections.anthropic}
-                        onCheckedChange={(checked) =>
-                          setActiveConnections({ ...activeConnections, anthropic: checked })
-                        }
-                      />
+              <Card>
+                <CardHeader>
+                  <CardTitle>Доступные провайдеры</CardTitle>
+                  <CardDescription>Список поддерживаемых платформ и их статус</CardDescription>
+                </CardHeader>
+                <CardContent className="grid md:grid-cols-2 gap-4">
+                  {[
+                    { provider: "OpenAI", status: activeProviders.includes("openai"), description: "Модели GPT-4o, GPT-3.5" },
+                    { provider: "Anthropic", status: activeProviders.includes("anthropic"), description: "Claude 3, Claude Instant" },
+                    { provider: "Google AI", status: activeProviders.includes("google"), description: "Gemini 1.5" },
+                    { provider: "Groq", status: activeProviders.includes("groq"), description: "Высокая скорость ответа" },
+                    { provider: "Ollama", status: activeProviders.includes("ollama"), description: "Локальные Llama модели" },
+                  ].map((item) => (
+                    <div key={item.provider} className="border rounded-lg p-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <h3 className="font-semibold">{item.provider}</h3>
+                        <Badge variant={item.status ? "default" : "outline"}>
+                          {item.status ? "Активен" : "Отключен"}
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-muted-foreground">{item.description}</p>
                     </div>
-                    <div className="space-y-2">
-                      <Label>API ключ</Label>
-                      <Input
-                        type="password"
-                        placeholder="sk-ant-..."
-                        value={apiKeys.anthropic}
-                        onChange={(e) => setApiKeys({ ...apiKeys, anthropic: e.target.value })}
-                      />
-                    </div>
-                    <Button variant="outline" size="sm">
-                      Тестировать подключение
-                    </Button>
-                  </CardContent>
-                </Card>
-
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Zap className="h-5 w-5" />
-                      Google AI
-                    </CardTitle>
-                    <CardDescription>Gemini Pro, PaLM и другие модели Google</CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label>Активно</Label>
-                      <Switch
-                        checked={activeConnections.google}
-                        onCheckedChange={(checked) => setActiveConnections({ ...activeConnections, google: checked })}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>API ключ</Label>
-                      <Input
-                        type="password"
-                        placeholder="AIza..."
-                        value={apiKeys.google}
-                        onChange={(e) => setApiKeys({ ...apiKeys, google: e.target.value })}
-                      />
-                    </div>
-                    <Button variant="outline" size="sm">
-                      Тестировать подключение
-                    </Button>
-                  </CardContent>
-                </Card>
-
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Shield className="h-5 w-5" />
-                      Hugging Face
-                    </CardTitle>
-                    <CardDescription>Доступ к тысячам открытых моделей</CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label>Активно</Label>
-                      <Switch defaultChecked />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>API токен</Label>
-                      <Input
-                        type="password"
-                        placeholder="hf_..."
-                        value={apiKeys.huggingface}
-                        onChange={(e) => setApiKeys({ ...apiKeys, huggingface: e.target.value })}
-                      />
-                    </div>
-                    <Button variant="outline" size="sm">
-                      Тестировать подключение
-                    </Button>
-                  </CardContent>
-                </Card>
-              </div>
+                  ))}
+                </CardContent>
+              </Card>
             </TabsContent>
 
             <TabsContent value="settings" className="space-y-6">
               <Card>
                 <CardHeader>
-                  <CardTitle>Общие настройки</CardTitle>
-                  <CardDescription>Конфигурация работы с AI моделями</CardDescription>
+                  <CardTitle>Рекомендации по безопасности</CardTitle>
+                  <CardDescription>Как хранить ключи и управлять доступом</CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-6">
-                  <div className="grid grid-cols-2 gap-6">
-                    <div className="space-y-2">
-                      <Label>Модель по умолчанию для текста</Label>
-                      <Select>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Выберите модель" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="gpt-4">GPT-4 (OpenAI)</SelectItem>
-                          <SelectItem value="claude-3">Claude 3.5 Sonnet</SelectItem>
-                          <SelectItem value="llama-3">Llama 3.1 8B (Локально)</SelectItem>
-                          <SelectItem value="gemini">Gemini Pro</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label>Модель для изображений</Label>
-                      <Select>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Выберите модель" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="dall-e-3">DALL-E 3</SelectItem>
-                          <SelectItem value="midjourney">Midjourney</SelectItem>
-                          <SelectItem value="stable-diffusion">Stable Diffusion</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  <div className="flex items-start gap-3">
+                    <Shield className="h-4 w-4 text-primary mt-1" />
+                    <p>Храните ключи шифрованными и ограничивайте доступ только доверенным членам команды.</p>
                   </div>
-
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <Label>Приоритет локальных моделей</Label>
-                        <p className="text-sm text-muted-foreground">Использовать локальные модели когда возможно</p>
-                      </div>
-                      <Switch defaultChecked />
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <Label>Автоматические обновления</Label>
-                        <p className="text-sm text-muted-foreground">Обновлять модели автоматически</p>
-                      </div>
-                      <Switch />
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <Label>Режим экономии</Label>
-                        <p className="text-sm text-muted-foreground">Использовать менее ресурсоемкие модели</p>
-                      </div>
-                      <Switch />
-                    </div>
+                  <div className="flex items-start gap-3">
+                    <Globe className="h-4 w-4 text-primary mt-1" />
+                    <p>Для кастомных endpoints используйте HTTPS и проверяйте сертификаты.</p>
                   </div>
-
-                  <div className="space-y-2">
-                    <Label>Максимальное использование GPU (%)</Label>
-                    <Input type="number" defaultValue="80" min="10" max="100" />
+                  <div className="flex items-start gap-3">
+                    <Zap className="h-4 w-4 text-primary mt-1" />
+                    <p>Настройте мониторинг и лимиты запросов, чтобы избежать неожиданных расходов.</p>
                   </div>
-
-                  <Button>Сохранить настройки</Button>
                 </CardContent>
               </Card>
             </TabsContent>

--- a/app/api/ai/chat/message/route.ts
+++ b/app/api/ai/chat/message/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import {
+  addChatMessage,
+  ensureChatHistory,
+  getChatHistory,
+  incrementUsage,
+  recordAIRequest,
+} from "@/lib/server/database"
+
+function buildAssistantReply(message: string, historyLength: number) {
+  return [
+    `Спасибо за сообщение! Я зафиксировал ваш запрос: «${message}».`,
+    "Вот что я могу предложить:",
+    historyLength > 3 ? "• У нас уже сложилась хорошая история диалога — продолжаем в том же духе." : "• Это один из первых запросов, поэтому я уточняю детали.",
+    "• Попробуйте сформулировать конечную цель, чтобы я подготовил точный ответ.",
+  ].join("\n")
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.message !== "string") {
+      return NextResponse.json({ error: "Введите сообщение" }, { status: 400 })
+    }
+
+    ensureChatHistory(user.id)
+    addChatMessage(user.id, { role: "user", content: body.message })
+    const history = getChatHistory(user.id)
+    const assistantMessage = buildAssistantReply(body.message, history.length)
+    addChatMessage(user.id, { role: "assistant", content: assistantMessage })
+
+    recordAIRequest({
+      userId: user.id,
+      type: "chat",
+      inputData: { message: body.message },
+      outputData: { reply: assistantMessage },
+      status: "completed",
+    })
+    incrementUsage(user.id, 64)
+
+    return NextResponse.json({ messages: getChatHistory(user.id) })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/ai/content/generate/route.ts
+++ b/app/api/ai/content/generate/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { incrementUsage, recordAIRequest } from "@/lib/server/database"
+
+function buildContent({
+  topic,
+  contentType,
+  tone,
+  length,
+}: {
+  topic: string
+  contentType: string
+  tone?: string
+  length?: string
+}) {
+  const toneLabel = tone ? `Тон: ${tone}.` : ""
+  const lengthLabel =
+    length === "short"
+      ? "Краткое содержание"
+      : length === "long"
+        ? "Расширенный материал"
+        : "Сбалансированный формат"
+
+  const sections = [
+    `# ${topic}\n\n${lengthLabel}. ${toneLabel}`,
+    "## Введение\n\n" +
+      `Раскрываем тему «${topic}» с акцентом на практическую ценность. Подготавливаем читателя к ключевым выводам и объясняем, почему вопрос важен именно сейчас.`,
+    "## Основные идеи\n\n" +
+      `1. Основное преимущество: «${topic}» открывает новые возможности и помогает принимать решения быстрее.\n2. Практическое применение: Опишите два-три сценария, где тема приносит максимальную выгоду.\n3. Советы по внедрению: Дайте пошаговый план, который можно адаптировать под разные команды.`,
+    "## Заключение\n\n" +
+      `Подведите итог и сформулируйте призыв к действию — предложите читателю сделать следующий шаг, например, протестировать идею или обсудить ее с коллегами.`,
+  ]
+
+  return sections.join("\n\n")
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.topic !== "string" || typeof body.contentType !== "string") {
+      return NextResponse.json({ error: "Укажите тему и тип контента" }, { status: 400 })
+    }
+
+    const content = buildContent({
+      topic: body.topic,
+      contentType: body.contentType,
+      tone: typeof body.tone === "string" ? body.tone : undefined,
+      length: typeof body.length === "string" ? body.length : undefined,
+    })
+
+    recordAIRequest({
+      userId: user.id,
+      type: "content_generation",
+      inputData: body,
+      outputData: { content },
+      status: "completed",
+    })
+    incrementUsage(user.id, 256)
+
+    return NextResponse.json({ content })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/ai/image/generate/route.ts
+++ b/app/api/ai/image/generate/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { incrementUsage, recordAIRequest } from "@/lib/server/database"
+
+function buildPlaceholderImage(prompt: string, style: string | undefined) {
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+  <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+    <defs>
+      <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#6366f1" />
+        <stop offset="100%" stop-color="#22d3ee" />
+      </linearGradient>
+    </defs>
+    <rect width="512" height="512" fill="url(#gradient)" rx="32" />
+    <text x="50%" y="45%" font-family="Inter, sans-serif" font-size="36" fill="#ffffff" text-anchor="middle" opacity="0.85">
+      ${style ?? "AI Helper"}
+    </text>
+    <text x="50%" y="70%" font-family="Inter, sans-serif" font-size="22" fill="#ffffff" text-anchor="middle" opacity="0.75">
+      ${prompt.slice(0, 60)}
+    </text>
+  </svg>`
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.prompt !== "string") {
+      return NextResponse.json({ error: "Введите промпт для генерации" }, { status: 400 })
+    }
+
+    const images = Array.from({ length: body.count && Number.isInteger(body.count) ? Math.max(1, Math.min(4, body.count)) : 1 }).map(
+      (_, index) => ({
+        id: `${index}`,
+        url: buildPlaceholderImage(body.prompt, typeof body.style === "string" ? body.style : undefined),
+      }),
+    )
+
+    recordAIRequest({
+      userId: user.id,
+      type: "image_generation",
+      inputData: body,
+      outputData: { images },
+      status: "completed",
+    })
+    incrementUsage(user.id, 512)
+
+    return NextResponse.json({ images })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/ai/marketing/ideas/route.ts
+++ b/app/api/ai/marketing/ideas/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { addMarketingIdea, incrementUsage, listMarketingIdeas, recordAIRequest } from "@/lib/server/database"
+
+function buildIdea(topic: string, channel: string, audience?: string) {
+  const base = `Акцент на теме «${topic}»`
+  const channelText = `Канал: ${channel}.`
+  const audienceText = audience ? `Целевая аудитория: ${audience}.` : ""
+  return [base, channelText, audienceText, "Предложение: расскажите кейс с реальными цифрами и предложите бесплатный чек-лист."].filter(Boolean).join(" ")
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.topic !== "string" || typeof body.channel !== "string") {
+      return NextResponse.json({ error: "Укажите тему и канал продвижения" }, { status: 400 })
+    }
+
+    const ideaText = buildIdea(body.topic, body.channel, typeof body.audience === "string" ? body.audience : undefined)
+    const idea = addMarketingIdea(user.id, {
+      topic: body.topic,
+      channel: body.channel,
+      idea: ideaText,
+    })
+
+    recordAIRequest({
+      userId: user.id,
+      type: "marketing_idea",
+      inputData: body,
+      outputData: { idea: ideaText },
+      status: "completed",
+    })
+    incrementUsage(user.id, 80)
+
+    return NextResponse.json({ idea, history: listMarketingIdeas(user.id) })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/ai/models/[id]/route.ts
+++ b/app/api/ai/models/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { deleteAIModel } from "@/lib/server/database"
+
+type Params = {
+  params: { id: string }
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  try {
+    const user = requireAuth(request)
+    const success = deleteAIModel(user.id, params.id)
+    if (!success) {
+      return NextResponse.json({ error: "Модель не найдена" }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/ai/models/route.ts
+++ b/app/api/ai/models/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { listAIModels, upsertAIModel } from "@/lib/server/database"
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const models = listAIModels(user.id)
+    return NextResponse.json({ models })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.provider !== "string" || typeof body.modelName !== "string") {
+      return NextResponse.json({ error: "Укажите провайдера и название модели" }, { status: 400 })
+    }
+
+    const model = upsertAIModel(user.id, {
+      provider: body.provider,
+      modelName: body.modelName,
+      apiKey: typeof body.apiKey === "string" ? body.apiKey : undefined,
+      endpointUrl: typeof body.endpointUrl === "string" ? body.endpointUrl : undefined,
+      parameters: typeof body.parameters === "object" && body.parameters ? body.parameters : {},
+      isActive: typeof body.isActive === "boolean" ? body.isActive : true,
+    })
+
+    return NextResponse.json({ model }, { status: 201 })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/ai/text/analyze/route.ts
+++ b/app/api/ai/text/analyze/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { incrementUsage, recordAIRequest } from "@/lib/server/database"
+
+function analyzeText(text: string) {
+  const sentences = text.split(/[.!?]+/).filter((item) => item.trim().length > 0)
+  const words = text
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter(Boolean)
+  const characters = text.replace(/\s/g, "").length
+  const readingTimeMinutes = Math.max(1, Math.round(words.length / 200))
+  const uniqueWords = new Set(words.map((word) => word.toLowerCase())).size
+
+  return {
+    wordCount: words.length,
+    sentenceCount: sentences.length,
+    readingTimeMinutes,
+    uniqueWords,
+    characterCount: characters,
+    readability: words.length / Math.max(1, sentences.length),
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.text !== "string") {
+      return NextResponse.json({ error: "Введите текст для анализа" }, { status: 400 })
+    }
+
+    const metrics = analyzeText(body.text)
+    recordAIRequest({
+      userId: user.id,
+      type: "text_analysis",
+      inputData: { text: body.text.slice(0, 2000) },
+      outputData: metrics,
+      status: "completed",
+    })
+    incrementUsage(user.id, 128)
+
+    return NextResponse.json({ metrics, suggestions: buildSuggestions(metrics) })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}
+
+function buildSuggestions(metrics: ReturnType<typeof analyzeText>) {
+  const suggestions: string[] = []
+  if (metrics.readability > 20) {
+    suggestions.push("Предложения слишком длинные — попробуйте разбить их на более короткие.")
+  }
+  if (metrics.uniqueWords / Math.max(1, metrics.wordCount) < 0.3) {
+    suggestions.push("Добавьте больше разнообразной лексики, чтобы избежать повторов.")
+  }
+  if (metrics.wordCount < 120) {
+    suggestions.push("Раскройте тему подробнее — текст получится убедительнее.")
+  }
+  if (suggestions.length === 0) {
+    suggestions.push("Текст выглядит отлично! Можно переходить к публикации.")
+  }
+  return suggestions
+}

--- a/app/api/ai/voice/transcribe/route.ts
+++ b/app/api/ai/voice/transcribe/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { incrementUsage, recordAIRequest } from "@/lib/server/database"
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.audio !== "string") {
+      return NextResponse.json({ error: "Передайте аудио в формате base64" }, { status: 400 })
+    }
+
+    const transcript = "Распознанный текст (демо): платформа успешно обрабатывает голосовые команды."
+    recordAIRequest({
+      userId: user.id,
+      type: "voice_transcription",
+      inputData: { audioLength: body.audio.length },
+      outputData: { transcript },
+      status: "completed",
+    })
+    incrementUsage(user.id, 96)
+
+    return NextResponse.json({ transcript })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server"
+import { findUserByEmail, issueResetToken } from "@/lib/server/database"
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => undefined)
+  if (!body || typeof body.email !== "string") {
+    return NextResponse.json({ error: "Некорректные данные" }, { status: 400 })
+  }
+
+  const user = findUserByEmail(body.email)
+  if (!user) {
+    // Не раскрываем существование пользователя
+    return NextResponse.json({ success: true })
+  }
+
+  const token = issueResetToken(user.id)
+  return NextResponse.json({ success: true, resetToken: token.token, expiresAt: token.expiresAt })
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+import { authenticateWithCredentials, createLoginSession } from "@/lib/server/auth"
+import { findUserByEmail } from "@/lib/server/database"
+
+function sanitizeUser(user: NonNullable<ReturnType<typeof findUserByEmail>>) {
+  const { passwordHash: _passwordHash, ...rest } = user
+  return rest
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => undefined)
+  if (!body || typeof body.email !== "string" || typeof body.password !== "string") {
+    return NextResponse.json({ error: "Некорректные данные" }, { status: 400 })
+  }
+
+  const user = authenticateWithCredentials(body.email, body.password)
+  if (!user) {
+    return NextResponse.json({ error: "Неверный email или пароль" }, { status: 401 })
+  }
+
+  createLoginSession(user.id)
+  return NextResponse.json({ user: sanitizeUser(user) })
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server"
+import { clearLoginSession } from "@/lib/server/auth"
+
+export async function POST() {
+  clearLoginSession()
+  return NextResponse.json({ success: true })
+}

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server"
+import { readUserFromCookies } from "@/lib/server/auth"
+
+export async function GET() {
+  const user = readUserFromCookies()
+  if (!user) {
+    return NextResponse.json({ user: null }, { status: 200 })
+  }
+  const { passwordHash: _passwordHash, ...rest } = user
+  return NextResponse.json({ user: rest })
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { createUser, findUserByEmail } from "@/lib/server/database"
+import { createLoginSession } from "@/lib/server/auth"
+
+function sanitizeUser(user: ReturnType<typeof createUser>) {
+  const { passwordHash: _passwordHash, ...rest } = user
+  return rest
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => undefined)
+  if (!body || typeof body.email !== "string" || typeof body.password !== "string" || typeof body.name !== "string") {
+    return NextResponse.json({ error: "Некорректные данные" }, { status: 400 })
+  }
+
+  const existing = findUserByEmail(body.email)
+  if (existing) {
+    return NextResponse.json({ error: "Пользователь с таким email уже существует" }, { status: 400 })
+  }
+
+  if (body.password.length < 8) {
+    return NextResponse.json({ error: "Пароль должен содержать минимум 8 символов" }, { status: 400 })
+  }
+
+  const user = createUser({ email: body.email, password: body.password, name: body.name })
+  createLoginSession(user.id)
+  return NextResponse.json({ user: sanitizeUser(user) }, { status: 201 })
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+import { consumeResetToken, updateUser } from "@/lib/server/database"
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => undefined)
+  if (!body || typeof body.token !== "string" || typeof body.password !== "string") {
+    return NextResponse.json({ error: "Некорректные данные" }, { status: 400 })
+  }
+
+  if (body.password.length < 8) {
+    return NextResponse.json({ error: "Пароль должен содержать минимум 8 символов" }, { status: 400 })
+  }
+
+  const resetToken = consumeResetToken(body.token)
+  if (!resetToken) {
+    return NextResponse.json({ error: "Ссылка для сброса недействительна" }, { status: 400 })
+  }
+
+  const user = updateUser(resetToken.userId, { password: body.password })
+  if (!user) {
+    return NextResponse.json({ error: "Пользователь не найден" }, { status: 404 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { getDashboardSnapshot, listAIRequests, listProjects } from "@/lib/server/database"
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const snapshot = getDashboardSnapshot(user.id)
+    const projects = listProjects(user.id)
+    const requests = listAIRequests(user.id)
+
+    return NextResponse.json({ snapshot, projects, requests })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/files/[id]/route.ts
+++ b/app/api/files/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { deleteFile, getFile } from "@/lib/server/database"
+
+type Params = {
+  params: { id: string }
+}
+
+export async function GET(request: NextRequest, { params }: Params) {
+  try {
+    const user = requireAuth(request)
+    const file = getFile(user.id, params.id)
+    if (!file) {
+      return NextResponse.json({ error: "Файл не найден" }, { status: 404 })
+    }
+    return NextResponse.json({ file })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  try {
+    const user = requireAuth(request)
+    const success = deleteFile(user.id, params.id)
+    if (!success) {
+      return NextResponse.json({ error: "Файл не найден" }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/files/upload/route.ts
+++ b/app/api/files/upload/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { saveFile } from "@/lib/server/database"
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.filename !== "string" || typeof body.mimeType !== "string" || typeof body.content !== "string") {
+      return NextResponse.json({ error: "Передайте имя файла, тип и содержимое" }, { status: 400 })
+    }
+
+    const file = saveFile({
+      userId: user.id,
+      filename: body.filename,
+      originalName: body.originalName && typeof body.originalName === "string" ? body.originalName : body.filename,
+      mimeType: body.mimeType,
+      sizeBytes: Buffer.from(body.content, "base64").byteLength,
+      storagePath: `memory://${body.filename}`,
+    })
+
+    return NextResponse.json({ file }, { status: 201 })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { deleteProject, getProject, updateProject } from "@/lib/server/database"
+
+type Params = {
+  params: { id: string }
+}
+
+export async function GET(request: NextRequest, { params }: Params) {
+  try {
+    const user = requireAuth(request)
+    const project = getProject(user.id, params.id)
+    if (!project) {
+      return NextResponse.json({ error: "Проект не найден" }, { status: 404 })
+    }
+    return NextResponse.json({ project })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: Params) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body) {
+      return NextResponse.json({ error: "Некорректные данные" }, { status: 400 })
+    }
+    const project = updateProject(user.id, params.id, body)
+    if (!project) {
+      return NextResponse.json({ error: "Проект не найден" }, { status: 404 })
+    }
+    return NextResponse.json({ project })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  try {
+    const user = requireAuth(request)
+    const success = deleteProject(user.id, params.id)
+    if (!success) {
+      return NextResponse.json({ error: "Проект не найден" }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { createProject, listProjects } from "@/lib/server/database"
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const projects = listProjects(user.id)
+    return NextResponse.json({ projects })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body || typeof body.name !== "string" || typeof body.type !== "string") {
+      return NextResponse.json({ error: "Некорректные данные" }, { status: 400 })
+    }
+    const project = createProject(user.id, {
+      name: body.name,
+      description: typeof body.description === "string" ? body.description : undefined,
+      type: body.type,
+      settings: typeof body.settings === "object" && body.settings ? body.settings : {},
+    })
+    return NextResponse.json({ project }, { status: 201 })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/api/users/profile/route.ts
+++ b/app/api/users/profile/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/server/auth"
+import { updateUser } from "@/lib/server/database"
+
+export async function PUT(request: NextRequest) {
+  try {
+    const user = requireAuth(request)
+    const body = await request.json().catch(() => undefined)
+    if (!body) {
+      return NextResponse.json({ error: "Некорректные данные" }, { status: 400 })
+    }
+
+    const updated = updateUser(user.id, {
+      name: typeof body.name === "string" ? body.name : undefined,
+      email: typeof body.email === "string" ? body.email : undefined,
+      avatarUrl: typeof body.avatarUrl === "string" ? body.avatarUrl : undefined,
+      subscriptionPlan: typeof body.subscriptionPlan === "string" ? body.subscriptionPlan : undefined,
+    })
+
+    if (!updated) {
+      return NextResponse.json({ error: "Пользователь не найден" }, { status: 404 })
+    }
+
+    const { passwordHash: _passwordHash, ...rest } = updated
+    return NextResponse.json({ user: rest })
+  } catch (error) {
+    return NextResponse.json({ error: "Требуется авторизация" }, { status: 401 })
+  }
+}

--- a/app/content-generation/page.tsx
+++ b/app/content-generation/page.tsx
@@ -11,8 +11,11 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { Brain, FileText, Download, Share2, Plus, Copy, RefreshCw, Sparkles, ArrowLeft, Wand2 } from "lucide-react"
 import Link from "next/link"
+import { apiClient } from "@/lib/api-client"
+import { useAuthContext } from "@/components/providers/auth-context"
 
 export default function ContentGenerationPage() {
+  const { user } = useAuthContext()
   const [topic, setTopic] = useState("")
   const [contentType, setContentType] = useState("")
   const [tone, setTone] = useState("")
@@ -20,27 +23,19 @@ export default function ContentGenerationPage() {
   const [isGenerating, setIsGenerating] = useState(false)
   const [generatedContent, setGeneratedContent] = useState("")
   const [editableContent, setEditableContent] = useState("")
+  const [error, setError] = useState<string | null>(null)
 
   const handleGenerate = async () => {
     if (!topic || !contentType) return
 
     setIsGenerating(true)
+    setError(null)
     try {
-      // TODO: Replace with actual API call to content generation service
-      // const response = await fetch('/api/generate-content', {
-      //   method: 'POST',
-      //   headers: { 'Content-Type': 'application/json' },
-      //   body: JSON.stringify({ topic, contentType, tone, length })
-      // })
-      // const data = await response.json()
-      // setGeneratedContent(data.content)
-      // setEditableContent(data.content)
-
-      // For now, show empty state until API is connected
-      setGeneratedContent("")
-      setEditableContent("")
+      const response = await apiClient.generateContent({ topic, contentType, tone, length })
+      setGeneratedContent(response.content)
+      setEditableContent(response.content)
     } catch (error) {
-      console.error("Content generation failed:", error)
+      setError((error as Error).message)
     } finally {
       setIsGenerating(false)
     }
@@ -62,6 +57,11 @@ export default function ContentGenerationPage() {
 
   return (
     <div className="min-h-screen bg-background">
+      {!user ? (
+        <div className="bg-destructive/10 text-destructive text-center py-2 text-sm">
+          Чтобы сохранять историю генераций, войдите в аккаунт
+        </div>
+      ) : null}
       {/* Header */}
       <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
@@ -180,6 +180,7 @@ export default function ContentGenerationPage() {
                     </>
                   )}
                 </Button>
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
               </CardContent>
             </Card>
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,12 +1,98 @@
+"use client"
+
+import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Separator } from "@/components/ui/separator"
-import { Brain, FileText, MessageSquare, Plus, Settings, Bell, Clock, BarChart3, Target, Sparkles } from "lucide-react"
+import {
+  Brain,
+  FileText,
+  MessageSquare,
+  Plus,
+  Settings,
+  Bell,
+  Clock,
+  BarChart3,
+  Target,
+  Sparkles,
+  RefreshCw,
+} from "lucide-react"
 import Link from "next/link"
+import { apiClient } from "@/lib/api-client"
+import { useAuthContext } from "@/components/providers/auth-context"
+
+type DashboardResponse = Awaited<ReturnType<typeof apiClient.dashboard>>
+
+const EMPTY_SUMMARY = {
+  projects: 0,
+  contentGenerated: 0,
+  textAnalyzed: 0,
+  chatMessages: 0,
+  marketingIdeas: 0,
+  usage: {
+    requestsUsed: 0,
+    requestsLimit: 0,
+    tokensUsed: 0,
+    tokensLimit: 0,
+  },
+  lastUpdated: "",
+}
 
 export default function DashboardPage() {
+  const { user, loading } = useAuthContext()
+  const [data, setData] = useState<DashboardResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const summary = data?.snapshot ?? EMPTY_SUMMARY
+
+  const loadDashboard = async () => {
+    setIsLoading(true)
+    try {
+      const response = await apiClient.dashboard()
+      setData(response)
+      setError(null)
+    } catch (error) {
+      setError((error as Error).message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!loading && user) {
+      loadDashboard()
+    }
+  }, [loading, user])
+
+  const isAuthenticated = Boolean(user)
+  const projects = data?.projects ?? []
+  const recentRequests = useMemo(() => {
+    return (data?.requests ?? []).slice(-5).reverse()
+  }, [data])
+
+  if (!loading && !isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-background flex flex-col items-center justify-center text-center px-4">
+        <Brain className="h-12 w-12 text-primary mb-6" />
+        <h1 className="text-3xl font-bold mb-2">Требуется авторизация</h1>
+        <p className="text-muted-foreground max-w-md mb-6">
+          Чтобы увидеть статистику и проекты, войдите в систему или создайте новый аккаунт.
+        </p>
+        <div className="flex gap-4">
+          <Button asChild>
+            <Link href="/login">Войти</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/register">Создать аккаунт</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
@@ -17,49 +103,67 @@ export default function DashboardPage() {
             <span className="text-2xl font-bold text-foreground">AI Helper</span>
           </div>
           <div className="flex items-center gap-4">
+            <Button variant="ghost" size="sm" onClick={loadDashboard} disabled={isLoading}>
+              <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
+            </Button>
             <Button variant="ghost" size="sm">
               <Bell className="h-4 w-4" />
             </Button>
-            <Button variant="ghost" size="sm">
-              <Settings className="h-4 w-4" />
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/settings">
+                <Settings className="h-4 w-4" />
+              </Link>
             </Button>
             <Avatar className="h-8 w-8">
-              <AvatarFallback>U</AvatarFallback>
+              <AvatarFallback>{user?.name?.[0]?.toUpperCase() ?? "U"}</AvatarFallback>
             </Avatar>
           </div>
         </div>
       </header>
 
       <div className="container mx-auto px-4 py-8">
+        {error ? (
+          <div className="mb-6 rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-destructive">
+            Не удалось загрузить данные: {error}
+          </div>
+        ) : null}
+
         <div className="grid lg:grid-cols-4 gap-6">
           {/* Sidebar */}
           <div className="lg:col-span-1">
             <Card>
               <CardHeader className="text-center pb-4">
                 <Avatar className="h-20 w-20 mx-auto mb-4">
-                  <AvatarFallback className="text-lg">U</AvatarFallback>
+                  <AvatarFallback className="text-lg">{user?.name?.[0]?.toUpperCase() ?? "U"}</AvatarFallback>
                 </Avatar>
-                <CardTitle className="text-xl">Пользователь</CardTitle>
-                <CardDescription>user@example.com</CardDescription>
+                <CardTitle className="text-xl">{user?.name ?? "Пользователь"}</CardTitle>
+                <CardDescription>{user?.email}</CardDescription>
                 <Badge variant="secondary" className="mt-2">
                   <Sparkles className="h-3 w-3 mr-1" />
-                  Pro план
+                  {user?.subscriptionPlan ? `${user.subscriptionPlan} план` : "Free план"}
                 </Badge>
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
                   <div className="text-center">
-                    <div className="text-2xl font-bold text-primary">0</div>
-                    <div className="text-sm text-muted-foreground">Запросов выполнено</div>
+                    <div className="text-2xl font-bold text-primary">{summary.contentGenerated + summary.textAnalyzed}</div>
+                    <div className="text-sm text-muted-foreground">AI запросов выполнено</div>
                   </div>
                   <Separator />
                   <div className="space-y-2">
                     <div className="flex justify-between text-sm">
                       <span>Использовано в этом месяце</span>
-                      <span className="font-medium">0/1000</span>
+                      <span className="font-medium">
+                        {summary.usage.requestsUsed}/{summary.usage.requestsLimit || 1000}
+                      </span>
                     </div>
                     <div className="w-full bg-muted rounded-full h-2">
-                      <div className="bg-primary h-2 rounded-full" style={{ width: "0%" }}></div>
+                      <div
+                        className="bg-primary h-2 rounded-full"
+                        style={{
+                          width: `${Math.min(100, Math.round((summary.usage.requestsUsed / Math.max(1, summary.usage.requestsLimit || 1000)) * 100))}%`,
+                        }}
+                      ></div>
                     </div>
                   </div>
                   <Button variant="outline" className="w-full bg-transparent" asChild>
@@ -75,69 +179,38 @@ export default function DashboardPage() {
 
           {/* Main Content */}
           <div className="lg:col-span-3 space-y-6">
-            {/* Welcome Section */}
-            <div>
-              <h1 className="text-3xl font-bold mb-2">Добро пожаловать!</h1>
-              <p className="text-muted-foreground">Управляйте своими AI-проектами и отслеживайте прогресс</p>
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <h1 className="text-3xl font-bold mb-2">Добро пожаловать, {user?.name ?? "в AI Helper"}!</h1>
+                <p className="text-muted-foreground">
+                  Управляйте своими AI-проектами и отслеживайте прогресс в реальном времени
+                </p>
+              </div>
+              <Badge variant="secondary">Обновлено: {summary.lastUpdated ? new Date(summary.lastUpdated).toLocaleString() : "–"}</Badge>
             </div>
 
             {/* Quick Stats */}
             <div className="grid md:grid-cols-4 gap-4">
-              <Card>
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-primary/10 rounded-lg">
-                      <FileText className="h-5 w-5 text-primary" />
-                    </div>
-                    <div>
-                      <div className="text-2xl font-bold">0</div>
-                      <div className="text-sm text-muted-foreground">Контент создан</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-accent/10 rounded-lg">
-                      <Target className="h-5 w-5 text-accent" />
-                    </div>
-                    <div>
-                      <div className="text-2xl font-bold">0</div>
-                      <div className="text-sm text-muted-foreground">Текстов проверено</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-primary/10 rounded-lg">
-                      <MessageSquare className="h-5 w-5 text-primary" />
-                    </div>
-                    <div>
-                      <div className="text-2xl font-bold">0</div>
-                      <div className="text-sm text-muted-foreground">Чат-сообщений</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-accent/10 rounded-lg">
-                      <BarChart3 className="h-5 w-5 text-accent" />
-                    </div>
-                    <div>
-                      <div className="text-2xl font-bold">0</div>
-                      <div className="text-sm text-muted-foreground">Идей для маркетинга</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+              <StatCard
+                icon={<FileText className="h-5 w-5 text-primary" />}
+                label="Контент создан"
+                value={summary.contentGenerated}
+              />
+              <StatCard
+                icon={<Target className="h-5 w-5 text-accent" />}
+                label="Текстов проверено"
+                value={summary.textAnalyzed}
+              />
+              <StatCard
+                icon={<MessageSquare className="h-5 w-5 text-primary" />}
+                label="Чат-сообщений"
+                value={summary.chatMessages}
+              />
+              <StatCard
+                icon={<BarChart3 className="h-5 w-5 text-accent" />}
+                label="Маркетинговых идей"
+                value={summary.marketingIdeas}
+              />
             </div>
 
             {/* Projects Section */}
@@ -157,21 +230,38 @@ export default function DashboardPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <div className="text-center py-12 text-muted-foreground">
-                  <div className="p-4 bg-muted rounded-full mb-4 w-fit mx-auto">
-                    <FileText className="h-8 w-8 text-muted-foreground" />
+                {projects.length === 0 ? (
+                  <div className="text-center py-12 text-muted-foreground">
+                    <div className="p-4 bg-muted rounded-full mb-4 w-fit mx-auto">
+                      <FileText className="h-8 w-8 text-muted-foreground" />
+                    </div>
+                    <h3 className="text-lg font-semibold mb-2">Пока нет проектов</h3>
+                    <p className="text-muted-foreground mb-4 max-w-sm mx-auto">
+                      Создайте свой первый AI-проект, чтобы начать работу
+                    </p>
+                    <Button asChild>
+                      <Link href="/projects/new">
+                        <Plus className="h-4 w-4 mr-2" />
+                        Создать проект
+                      </Link>
+                    </Button>
                   </div>
-                  <h3 className="text-lg font-semibold mb-2">Пока нет проектов</h3>
-                  <p className="text-muted-foreground mb-4 max-w-sm mx-auto">
-                    Создайте свой первый AI-проект, чтобы начать работу
-                  </p>
-                  <Button asChild>
-                    <Link href="/projects/new">
-                      <Plus className="h-4 w-4 mr-2" />
-                      Создать проект
-                    </Link>
-                  </Button>
-                </div>
+                ) : (
+                  <div className="grid gap-4">
+                    {projects.map((project) => (
+                      <div key={project.id} className="border rounded-lg p-4">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <h3 className="text-lg font-semibold">{project.name}</h3>
+                            <p className="text-sm text-muted-foreground">Тип: {project.type}</p>
+                          </div>
+                          <Badge variant="outline">{new Date(project.updatedAt).toLocaleDateString()}</Badge>
+                        </div>
+                        {project.description ? <p className="text-sm mt-2 text-muted-foreground">{project.description}</p> : null}
+                      </div>
+                    ))}
+                  </div>
+                )}
               </CardContent>
             </Card>
 
@@ -182,15 +272,33 @@ export default function DashboardPage() {
                 <CardDescription>История ваших взаимодействий с AI Helper</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="text-center py-12 text-muted-foreground">
-                  <div className="p-4 bg-muted rounded-full mb-4 w-fit mx-auto">
-                    <Clock className="h-8 w-8 text-muted-foreground" />
+                {recentRequests.length === 0 ? (
+                  <div className="text-center py-12 text-muted-foreground">
+                    <div className="p-4 bg-muted rounded-full mb-4 w-fit mx-auto">
+                      <Clock className="h-8 w-8 text-muted-foreground" />
+                    </div>
+                    <h3 className="text-lg font-semibold mb-2">Пока нет активности</h3>
+                    <p className="text-muted-foreground mb-4 max-w-sm mx-auto">
+                      Начните использовать AI-инструменты, чтобы увидеть историю активности
+                    </p>
                   </div>
-                  <h3 className="text-lg font-semibold mb-2">Пока нет активности</h3>
-                  <p className="text-muted-foreground mb-4 max-w-sm mx-auto">
-                    Начните использовать AI-инструменты, чтобы увидеть историю активности
-                  </p>
-                </div>
+                ) : (
+                  <ul className="space-y-3">
+                    {recentRequests.map((request) => (
+                      <li key={request.id} className="border rounded-lg p-4">
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium">{formatRequestType(request.type)}</span>
+                          <span className="text-sm text-muted-foreground">
+                            {new Date(request.createdAt).toLocaleString()}
+                          </span>
+                        </div>
+                        <p className="text-sm text-muted-foreground mt-2">
+                          Статус: {request.status === "completed" ? "Выполнено" : request.status}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </CardContent>
             </Card>
 
@@ -198,65 +306,14 @@ export default function DashboardPage() {
             <Card>
               <CardHeader>
                 <CardTitle>Быстрые действия</CardTitle>
-                <CardDescription>Начните работу с AI-инструментами</CardDescription>
+                <CardDescription>Начните работу с инструментами</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="grid md:grid-cols-2 gap-4">
-                  <Button variant="outline" className="h-auto p-4 justify-start bg-transparent" asChild>
-                    <Link href="/content-generation">
-                      <div className="flex items-center gap-3">
-                        <div className="p-2 bg-primary/10 rounded-lg">
-                          <FileText className="h-5 w-5 text-primary" />
-                        </div>
-                        <div className="text-left">
-                          <div className="font-medium">Создать контент</div>
-                          <div className="text-sm text-muted-foreground">Генерация текстов и постов</div>
-                        </div>
-                      </div>
-                    </Link>
-                  </Button>
-
-                  <Button variant="outline" className="h-auto p-4 justify-start bg-transparent" asChild>
-                    <Link href="/text-analysis">
-                      <div className="flex items-center gap-3">
-                        <div className="p-2 bg-accent/10 rounded-lg">
-                          <Target className="h-5 w-5 text-accent" />
-                        </div>
-                        <div className="text-left">
-                          <div className="font-medium">Анализ текста</div>
-                          <div className="text-sm text-muted-foreground">Проверка и улучшение</div>
-                        </div>
-                      </div>
-                    </Link>
-                  </Button>
-
-                  <Button variant="outline" className="h-auto p-4 justify-start bg-transparent" asChild>
-                    <Link href="/chatbot">
-                      <div className="flex items-center gap-3">
-                        <div className="p-2 bg-primary/10 rounded-lg">
-                          <MessageSquare className="h-5 w-5 text-primary" />
-                        </div>
-                        <div className="text-left">
-                          <div className="font-medium">Чат-бот</div>
-                          <div className="text-sm text-muted-foreground">Настройка автоответов</div>
-                        </div>
-                      </div>
-                    </Link>
-                  </Button>
-
-                  <Button variant="outline" className="h-auto p-4 justify-start bg-transparent" asChild>
-                    <Link href="/marketing">
-                      <div className="flex items-center gap-3">
-                        <div className="p-2 bg-accent/10 rounded-lg">
-                          <BarChart3 className="h-5 w-5 text-accent" />
-                        </div>
-                        <div className="text-left">
-                          <div className="font-medium">Маркетинг</div>
-                          <div className="text-sm text-muted-foreground">Идеи и аналитика</div>
-                        </div>
-                      </div>
-                    </Link>
-                  </Button>
+                  <QuickAction title="Генерация контента" description="Создать текст" href="/content-generation" />
+                  <QuickAction title="Анализ текста" description="Проверить документ" href="/text-analysis" />
+                  <QuickAction title="Чат-бот" description="Побеседовать с AI" href="/chatbot" />
+                  <QuickAction title="Маркетинг" description="Получить идеи" href="/marketing" />
                 </div>
               </CardContent>
             </Card>
@@ -265,4 +322,61 @@ export default function DashboardPage() {
       </div>
     </div>
   )
+}
+
+type StatCardProps = {
+  icon: ReactNode
+  label: string
+  value: number
+}
+
+function StatCard({ icon, label, value }: StatCardProps) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-primary/10 rounded-lg">{icon}</div>
+          <div>
+            <div className="text-2xl font-bold">{value}</div>
+            <div className="text-sm text-muted-foreground">{label}</div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+type QuickActionProps = {
+  title: string
+  description: string
+  href: string
+}
+
+function QuickAction({ title, description, href }: QuickActionProps) {
+  return (
+    <div className="border rounded-lg p-4">
+      <h3 className="font-semibold mb-1">{title}</h3>
+      <p className="text-sm text-muted-foreground mb-3">{description}</p>
+      <Button variant="outline" size="sm" className="bg-transparent" asChild>
+        <Link href={href}>Открыть</Link>
+      </Button>
+    </div>
+  )
+}
+
+function formatRequestType(type: string) {
+  switch (type) {
+    case "content_generation":
+      return "Генерация контента"
+    case "text_analysis":
+      return "Анализ текста"
+    case "chat":
+      return "Чат-бот"
+    case "image_generation":
+      return "Генерация изображений"
+    case "marketing_idea":
+      return "Маркетинг"
+    default:
+      return type
+  }
 }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,11 +1,39 @@
+"use client"
+
+import { FormEvent, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Brain, Mail, ArrowLeft } from "lucide-react"
 import Link from "next/link"
+import { apiClient } from "@/lib/api-client"
 
 export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+    setMessage(null)
+    try {
+      const response = await apiClient.forgotPassword({ email })
+      setMessage(
+        response.resetToken
+          ? `Ссылка для сброса (демо токен): ${response.resetToken}`
+          : "Если email зарегистрирован, мы отправили инструкции по восстановлению",
+      )
+    } catch (error) {
+      setError((error as Error).message)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <div className="w-full max-w-md">
@@ -26,17 +54,28 @@ export default function ForgotPasswordPage() {
             <CardDescription>Введите ваш email для получения ссылки на восстановление пароля</CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <form className="space-y-4">
+            <form className="space-y-4" onSubmit={handleSubmit}>
               <div className="space-y-2">
                 <Label htmlFor="email">Email</Label>
                 <div className="relative">
                   <Mail className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                  <Input id="email" type="email" placeholder="your@email.com" className="pl-10" required />
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="your@email.com"
+                    className="pl-10"
+                    required
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                  />
                 </div>
               </div>
 
-              <Button type="submit" className="w-full" size="lg">
-                Отправить ссылку
+              {error ? <p className="text-sm text-destructive">{error}</p> : null}
+              {message ? <p className="text-sm text-primary">{message}</p> : null}
+
+              <Button type="submit" className="w-full" size="lg" disabled={isSubmitting}>
+                {isSubmitting ? "Отправляем..." : "Отправить ссылку"}
               </Button>
             </form>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import { Inter, Manrope } from "next/font/google"
 import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
+import { AuthProvider } from "@/components/providers/auth-context"
 import "./globals.css"
 
 const inter = Inter({
@@ -32,7 +33,9 @@ export default function RootLayout({
   return (
     <html lang="ru">
       <body className={`font-sans ${inter.variable} ${manrope.variable}`}>
-        <Suspense fallback={null}>{children}</Suspense>
+        <AuthProvider>
+          <Suspense fallback={null}>{children}</Suspense>
+        </AuthProvider>
         <Analytics />
       </body>
     </html>

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -1,3 +1,6 @@
+"use client"
+
+import { FormEvent, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -5,10 +8,102 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
-import { Brain, FileText, MessageSquare, Target, BarChart3, ArrowLeft } from "lucide-react"
+import { Brain, FileText, MessageSquare, Target, BarChart3, ArrowLeft, CheckCircle2 } from "lucide-react"
 import Link from "next/link"
+import { apiClient } from "@/lib/api-client"
+
+const PROJECT_TYPES = [
+  {
+    id: "content",
+    title: "Генерация контента",
+    description: "Создание текстов, постов для соцсетей, email-рассылок",
+    icon: FileText,
+    badge: "Популярный",
+    iconClass: "text-primary",
+    backgroundClass: "bg-primary/10",
+  },
+  {
+    id: "analysis",
+    title: "Анализ текста",
+    description: "Проверка грамматики, стиля, SEO-оптимизация",
+    icon: Target,
+    iconClass: "text-accent",
+    backgroundClass: "bg-accent/10",
+  },
+  {
+    id: "chatbot",
+    title: "Чат-бот",
+    description: "Автоматизация общения с клиентами",
+    icon: MessageSquare,
+    iconClass: "text-primary",
+    backgroundClass: "bg-primary/10",
+  },
+  {
+    id: "marketing",
+    title: "Маркетинговые идеи",
+    description: "Генерация идей и анализ эффективности",
+    icon: BarChart3,
+    iconClass: "text-accent",
+    backgroundClass: "bg-accent/10",
+  },
+] as const
 
 export default function NewProjectPage() {
+  const [type, setType] = useState<typeof PROJECT_TYPES[number]["id"] | "">("content")
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [industry, setIndustry] = useState("")
+  const [audience, setAudience] = useState("")
+  const [tone, setTone] = useState("")
+  const [language, setLanguage] = useState("ru")
+  const [keywords, setKeywords] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!name.trim()) {
+      setError("Укажите название проекта")
+      return
+    }
+    if (!type) {
+      setError("Выберите тип проекта")
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      await apiClient.createProject({
+        name,
+        description,
+        type,
+        settings: {
+          industry,
+          audience,
+          tone,
+          language,
+          keywords: keywords.split(",").map((item) => item.trim()).filter(Boolean),
+        },
+      })
+      setSuccess("Проект успешно создан! Вы можете вернуться в панель управления.")
+      setName("")
+      setDescription("")
+      setIndustry("")
+      setAudience("")
+      setTone("")
+      setLanguage("ru")
+      setKeywords("")
+    } catch (error) {
+      setError((error as Error).message)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
@@ -33,7 +128,7 @@ export default function NewProjectPage() {
           <p className="text-muted-foreground">Настройте проект для работы с AI-инструментами</p>
         </div>
 
-        <div className="space-y-6">
+        <form className="space-y-6" onSubmit={handleSubmit}>
           {/* Project Type Selection */}
           <Card>
             <CardHeader>
@@ -42,56 +137,35 @@ export default function NewProjectPage() {
             </CardHeader>
             <CardContent>
               <div className="grid md:grid-cols-2 gap-4">
-                <div className="p-4 border border-border rounded-lg hover:bg-muted/50 transition-colors cursor-pointer">
-                  <div className="flex items-center gap-3 mb-3">
-                    <div className="p-2 bg-primary/10 rounded-lg">
-                      <FileText className="h-5 w-5 text-primary" />
+                {PROJECT_TYPES.map((projectType) => {
+                  const Icon = projectType.icon
+                  return (
+                  <button
+                    type="button"
+                    key={projectType.id}
+                    onClick={() => setType(projectType.id)}
+                    className={`p-4 border rounded-lg text-left transition-colors ${
+                      type === projectType.id ? "border-primary bg-primary/5" : "border-border hover:bg-muted/50"
+                    }`}
+                  >
+                    <div className="flex items-center gap-3 mb-3">
+                      <div className={`p-2 rounded-lg ${projectType.backgroundClass}`}>
+                        <Icon className={`h-5 w-5 ${projectType.iconClass}`} />
+                      </div>
+                      <div>
+                        <h3 className="font-semibold flex items-center gap-2">
+                          {projectType.title}
+                          {projectType.badge ? (
+                            <Badge variant="secondary" className="uppercase text-xs">
+                              {projectType.badge}
+                            </Badge>
+                          ) : null}
+                        </h3>
+                      </div>
                     </div>
-                    <div>
-                      <h3 className="font-semibold">Генерация контента</h3>
-                      <Badge variant="secondary" className="mt-1">
-                        Популярный
-                      </Badge>
-                    </div>
-                  </div>
-                  <p className="text-sm text-muted-foreground">Создание текстов, постов для соцсетей, email-рассылок</p>
-                </div>
-
-                <div className="p-4 border border-border rounded-lg hover:bg-muted/50 transition-colors cursor-pointer">
-                  <div className="flex items-center gap-3 mb-3">
-                    <div className="p-2 bg-accent/10 rounded-lg">
-                      <Target className="h-5 w-5 text-accent" />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold">Анализ текста</h3>
-                    </div>
-                  </div>
-                  <p className="text-sm text-muted-foreground">Проверка грамматики, стиля, SEO-оптимизация</p>
-                </div>
-
-                <div className="p-4 border border-border rounded-lg hover:bg-muted/50 transition-colors cursor-pointer">
-                  <div className="flex items-center gap-3 mb-3">
-                    <div className="p-2 bg-primary/10 rounded-lg">
-                      <MessageSquare className="h-5 w-5 text-primary" />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold">Чат-бот</h3>
-                    </div>
-                  </div>
-                  <p className="text-sm text-muted-foreground">Автоматизация общения с клиентами</p>
-                </div>
-
-                <div className="p-4 border border-border rounded-lg hover:bg-muted/50 transition-colors cursor-pointer">
-                  <div className="flex items-center gap-3 mb-3">
-                    <div className="p-2 bg-accent/10 rounded-lg">
-                      <BarChart3 className="h-5 w-5 text-accent" />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold">Маркетинговые идеи</h3>
-                    </div>
-                  </div>
-                  <p className="text-sm text-muted-foreground">Генерация идей и анализ эффективности</p>
-                </div>
+                    <p className="text-sm text-muted-foreground">{projectType.description}</p>
+                  </button>
+                })}
               </div>
             </CardContent>
           </Card>
@@ -105,19 +179,31 @@ export default function NewProjectPage() {
             <CardContent className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="projectName">Название проекта</Label>
-                <Input id="projectName" placeholder="Например: Email-кампания 'Весенние скидки'" />
+                <Input
+                  id="projectName"
+                  placeholder="Например: Email-кампания 'Весенние скидки'"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  required
+                />
               </div>
 
               <div className="space-y-2">
                 <Label htmlFor="projectDescription">Описание</Label>
-                <Textarea id="projectDescription" placeholder="Опишите цели и задачи проекта..." rows={3} />
+                <Textarea
+                  id="projectDescription"
+                  placeholder="Опишите цели и задачи проекта..."
+                  rows={3}
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                />
               </div>
 
               <div className="grid md:grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="industry">Сфера деятельности</Label>
-                  <Select>
-                    <SelectTrigger>
+                  <Select value={industry} onValueChange={setIndustry}>
+                    <SelectTrigger id="industry">
                       <SelectValue placeholder="Выберите сферу" />
                     </SelectTrigger>
                     <SelectContent>
@@ -134,8 +220,8 @@ export default function NewProjectPage() {
 
                 <div className="space-y-2">
                   <Label htmlFor="targetAudience">Целевая аудитория</Label>
-                  <Select>
-                    <SelectTrigger>
+                  <Select value={audience} onValueChange={setAudience}>
+                    <SelectTrigger id="targetAudience">
                       <SelectValue placeholder="Выберите аудиторию" />
                     </SelectTrigger>
                     <SelectContent>
@@ -158,8 +244,8 @@ export default function NewProjectPage() {
             <CardContent className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="tone">Тон общения</Label>
-                <Select>
-                  <SelectTrigger>
+                <Select value={tone} onValueChange={setTone}>
+                  <SelectTrigger id="tone">
                     <SelectValue placeholder="Выберите тон" />
                   </SelectTrigger>
                   <SelectContent>
@@ -174,8 +260,8 @@ export default function NewProjectPage() {
 
               <div className="space-y-2">
                 <Label htmlFor="language">Язык контента</Label>
-                <Select defaultValue="ru">
-                  <SelectTrigger>
+                <Select value={language} onValueChange={setLanguage}>
+                  <SelectTrigger id="language">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -189,20 +275,35 @@ export default function NewProjectPage() {
 
               <div className="space-y-2">
                 <Label htmlFor="keywords">Ключевые слова</Label>
-                <Input id="keywords" placeholder="Введите ключевые слова через запятую" />
+                <Input
+                  id="keywords"
+                  placeholder="Введите ключевые слова через запятую"
+                  value={keywords}
+                  onChange={(event) => setKeywords(event.target.value)}
+                />
                 <p className="text-sm text-muted-foreground">Эти слова будут учитываться при генерации контента</p>
               </div>
             </CardContent>
           </Card>
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          {success ? (
+            <div className="flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/5 px-4 py-3 text-sm text-primary">
+              <CheckCircle2 className="h-4 w-4" />
+              {success}
+            </div>
+          ) : null}
 
           {/* Action Buttons */}
           <div className="flex justify-end gap-3">
             <Button variant="outline" asChild>
               <Link href="/dashboard">Отменить</Link>
             </Button>
-            <Button>Создать проект</Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Сохраняем..." : "Создать проект"}
+            </Button>
           </div>
-        </div>
+        </form>
       </div>
     </div>
   )

--- a/app/text-analysis/page.tsx
+++ b/app/text-analysis/page.tsx
@@ -1,103 +1,102 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo, useState, type ComponentType } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
-import { Progress } from "@/components/ui/progress"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Separator } from "@/components/ui/separator"
 import {
   Target,
   ArrowLeft,
-  CheckCircle,
-  AlertTriangle,
-  XCircle,
   RefreshCw,
-  Save,
   FileText,
   Eye,
   BookOpen,
-  Zap,
-  TrendingUp,
-  Users,
+  Brain,
+  BarChart3,
+  AlertTriangle,
+  CheckCircle2,
 } from "lucide-react"
 import Link from "next/link"
+import { apiClient } from "@/lib/api-client"
+import { useAuthContext } from "@/components/providers/auth-context"
 
-interface AnalysisResult {
-  grammar: {
-    score: number
-    issues: Array<{
-      type: string
-      message: string
-      suggestion: string
-      position: number
-    }>
-  }
-  style: {
-    score: number
-    readability: number
-    tone: string
-    suggestions: string[]
-  }
-  seo: {
-    score: number
-    keywords: string[]
-    recommendations: string[]
-  }
-  stats: {
-    words: number
-    characters: number
-    sentences: number
-    paragraphs: number
-    readingTime: number
-  }
+type AnalysisResponse = Awaited<ReturnType<typeof apiClient.analyzeText>>
+
+type Metric = {
+  label: string
+  value: number | string
+  icon: ComponentType<{ className?: string }>
+  accent?: "primary" | "accent"
+  description: string
 }
 
 export default function TextAnalysisPage() {
+  const { user } = useAuthContext()
   const [inputText, setInputText] = useState("")
   const [isAnalyzing, setIsAnalyzing] = useState(false)
-  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null)
+  const [result, setResult] = useState<AnalysisResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const metrics: Metric[] = useMemo(() => {
+    if (!result) return []
+    return [
+      {
+        label: "Слов",
+        value: result.metrics.wordCount,
+        icon: FileText,
+        accent: "primary",
+        description: "Количество слов помогает оценить объём материала",
+      },
+      {
+        label: "Предложений",
+        value: result.metrics.sentenceCount,
+        icon: Brain,
+        accent: "accent",
+        description: "Чем меньше предложений при большом объёме, тем сложнее текст",
+      },
+      {
+        label: "Минут чтения",
+        value: result.metrics.readingTimeMinutes,
+        icon: BookOpen,
+        accent: "primary",
+        description: "Оценка времени чтения при скорости 200 слов в минуту",
+      },
+      {
+        label: "Уникальных слов",
+        value: result.metrics.uniqueWords,
+        icon: BarChart3,
+        accent: "accent",
+        description: "Чем выше разнообразие лексики, тем интереснее материал",
+      },
+    ]
+  }, [result])
 
   const handleAnalyze = async () => {
     if (!inputText.trim()) return
-
     setIsAnalyzing(true)
-
+    setError(null)
     try {
-      // TODO: Replace with actual API call to text analysis service
-      // const response = await fetch('/api/analyze-text', {
-      //   method: 'POST',
-      //   headers: { 'Content-Type': 'application/json' },
-      //   body: JSON.stringify({ text: inputText })
-      // })
-      // const data = await response.json()
-      // setAnalysisResult(data)
-
-      // For now, show empty state until API is connected
-      setAnalysisResult(null)
+      const response = await apiClient.analyzeText({ text: inputText })
+      setResult(response)
     } catch (error) {
-      console.error("Text analysis failed:", error)
+      setError((error as Error).message)
+      setResult(null)
     } finally {
       setIsAnalyzing(false)
     }
   }
 
-  const getScoreColor = (score: number) => {
-    if (score >= 80) return "text-green-600"
-    if (score >= 60) return "text-yellow-600"
-    return "text-red-600"
-  }
-
-  const getScoreIcon = (score: number) => {
-    if (score >= 80) return <CheckCircle className="h-4 w-4 text-green-600" />
-    if (score >= 60) return <AlertTriangle className="h-4 w-4 text-yellow-600" />
-    return <XCircle className="h-4 w-4 text-red-600" />
-  }
-
   return (
     <div className="min-h-screen bg-background">
+      {!user ? (
+        <div className="bg-muted/40 border-b border-border text-center text-sm py-2">
+          Войдите в аккаунт, чтобы сохранять отчёты по анализу текста
+        </div>
+      ) : null}
+
       {/* Header */}
       <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
@@ -114,22 +113,18 @@ export default function TextAnalysisPage() {
               </div>
               <div>
                 <h1 className="text-xl font-bold">Анализ текста</h1>
-                <p className="text-sm text-muted-foreground">Проверка грамматики, стиля и SEO</p>
+                <p className="text-sm text-muted-foreground">Проверка читаемости и качества контента</p>
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary">
-              <Target className="h-3 w-3 mr-1" />
-              AI-анализ
-            </Badge>
-          </div>
+          <Badge variant="secondary" className="uppercase tracking-wide text-xs">
+            AI-анализ
+          </Badge>
         </div>
       </header>
 
       <div className="container mx-auto px-4 py-8">
         <div className="grid lg:grid-cols-2 gap-8">
-          {/* Input Section */}
           <div className="space-y-6">
             <Card>
               <CardHeader>
@@ -137,33 +132,28 @@ export default function TextAnalysisPage() {
                   <FileText className="h-5 w-5 text-accent" />
                   Текст для анализа
                 </CardTitle>
-                <CardDescription>Вставьте или введите текст для проверки</CardDescription>
+                <CardDescription>Вставьте или введите текст для проверки качества</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <Textarea
-                  placeholder="Вставьте ваш текст здесь для анализа грамматики, стиля и SEO-оптимизации..."
+                  placeholder="Вставьте ваш текст здесь..."
                   value={inputText}
-                  onChange={(e) => setInputText(e.target.value)}
-                  className="min-h-[300px] resize-none"
+                  onChange={(event) => setInputText(event.target.value)}
+                  className="min-h-[280px] resize-none"
                 />
 
                 <div className="flex items-center justify-between text-sm text-muted-foreground">
                   <div className="flex items-center gap-4">
-                    <span>Слов: {inputText.split(" ").filter((word) => word.length > 0).length}</span>
+                    <span>Слов: {inputText.trim() ? inputText.trim().split(/\s+/).length : 0}</span>
                     <span>Символов: {inputText.length}</span>
                   </div>
                   <div className="flex items-center gap-1">
                     <Eye className="h-3 w-3" />
-                    <span>~{Math.ceil(inputText.split(" ").length / 200)} мин чтения</span>
+                    <span>~{Math.max(1, Math.ceil((inputText.trim().split(/\s+/).length || 1) / 200))} мин чтения</span>
                   </div>
                 </div>
 
-                <Button
-                  onClick={handleAnalyze}
-                  disabled={!inputText.trim() || isAnalyzing}
-                  className="w-full"
-                  size="lg"
-                >
+                <Button onClick={handleAnalyze} disabled={!inputText.trim() || isAnalyzing} className="w-full" size="lg">
                   {isAnalyzing ? (
                     <>
                       <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
@@ -176,255 +166,140 @@ export default function TextAnalysisPage() {
                     </>
                   )}
                 </Button>
+
+                {error ? (
+                  <Alert variant="destructive">
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                ) : null}
               </CardContent>
             </Card>
 
-            {/* Quick Examples */}
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">Примеры для анализа</CardTitle>
-                <CardDescription>Попробуйте анализ на готовых текстах</CardDescription>
+                <CardTitle className="text-lg">Быстрые примеры</CardTitle>
+                <CardDescription>Проверьте работу анализа на готовых текстах</CardDescription>
               </CardHeader>
-              <CardContent>
-                <div className="space-y-2">
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start h-auto p-3 bg-transparent"
-                    onClick={() =>
-                      setInputText(
-                        "Искусственный интеллект революционизирует современный бизнес. Компании используют AI для автоматизации процессов, улучшения клиентского сервиса и принятия более обоснованных решений. Однако внедрение AI требует тщательного планирования и понимания потенциальных рисков.",
-                      )
-                    }
-                  >
-                    <div className="text-left">
-                      <div className="font-medium">Статья об AI</div>
-                      <div className="text-sm text-muted-foreground">Пример делового текста</div>
-                    </div>
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start h-auto p-3 bg-transparent"
-                    onClick={() =>
-                      setInputText(
-                        "Добро пожаловать в наш магазин! Мы предлагаем широкий ассортимент качественных товаров по доступным ценам. Наша команда профессионалов готова помочь вам выбрать идеальный продукт. Не упустите возможность воспользоваться специальными предложениями!",
-                      )
-                    }
-                  >
-                    <div className="text-left">
-                      <div className="font-medium">Маркетинговый текст</div>
-                      <div className="text-sm text-muted-foreground">Пример продающего контента</div>
-                    </div>
-                  </Button>
-                </div>
+              <CardContent className="space-y-2">
+                <Button
+                  variant="outline"
+                  className="w-full justify-start h-auto p-3 bg-transparent"
+                  onClick={() =>
+                    setInputText(
+                      "Искусственный интеллект помогает компаниям принимать решения быстрее. Алгоритмы анализируют данные в режиме реального времени и подсказывают оптимальные действия для роста бизнеса.",
+                    )
+                  }
+                >
+                  <div className="text-left">
+                    <div className="font-medium">Статья об AI</div>
+                    <div className="text-sm text-muted-foreground">Пример делового текста</div>
+                  </div>
+                </Button>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start h-auto p-3 bg-transparent"
+                  onClick={() =>
+                    setInputText(
+                      "Добро пожаловать! Мы подготовили подборку лучших предложений недели. Выбирайте понравившиеся товары, а мы доставим заказ за 24 часа.",
+                    )
+                  }
+                >
+                  <div className="text-left">
+                    <div className="font-medium">Маркетинговый текст</div>
+                    <div className="text-sm text-muted-foreground">Пример продающего контента</div>
+                  </div>
+                </Button>
               </CardContent>
             </Card>
           </div>
 
-          {/* Results Section */}
           <div className="space-y-6">
-            {analysisResult ? (
+            {result ? (
               <>
-                {/* Overall Scores */}
                 <Card>
                   <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <TrendingUp className="h-5 w-5 text-accent" />
-                      Общая оценка
-                    </CardTitle>
+                    <CardTitle>Ключевые метрики</CardTitle>
+                    <CardDescription>
+                      Сводка по тексту и рекомендации на основе внутреннего алгоритма AI Helper
+                    </CardDescription>
                   </CardHeader>
-                  <CardContent>
-                    <div className="grid grid-cols-3 gap-4">
-                      <div className="text-center">
-                        <div className="flex items-center justify-center gap-1 mb-2">
-                          {getScoreIcon(analysisResult.grammar.score)}
-                          <span className={`text-2xl font-bold ${getScoreColor(analysisResult.grammar.score)}`}>
-                            {analysisResult.grammar.score}
-                          </span>
-                        </div>
-                        <div className="text-sm text-muted-foreground">Грамматика</div>
-                        <Progress value={analysisResult.grammar.score} className="mt-2" />
-                      </div>
-                      <div className="text-center">
-                        <div className="flex items-center justify-center gap-1 mb-2">
-                          {getScoreIcon(analysisResult.style.score)}
-                          <span className={`text-2xl font-bold ${getScoreColor(analysisResult.style.score)}`}>
-                            {analysisResult.style.score}
-                          </span>
-                        </div>
-                        <div className="text-sm text-muted-foreground">Стиль</div>
-                        <Progress value={analysisResult.style.score} className="mt-2" />
-                      </div>
-                      <div className="text-center">
-                        <div className="flex items-center justify-center gap-1 mb-2">
-                          {getScoreIcon(analysisResult.seo.score)}
-                          <span className={`text-2xl font-bold ${getScoreColor(analysisResult.seo.score)}`}>
-                            {analysisResult.seo.score}
-                          </span>
-                        </div>
-                        <div className="text-sm text-muted-foreground">SEO</div>
-                        <Progress value={analysisResult.seo.score} className="mt-2" />
-                      </div>
+                  <CardContent className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                      {metrics.map((metric) => {
+                        const Icon = metric.icon
+                        const accent = metric.accent === "accent" ? "bg-accent/10 text-accent" : "bg-primary/10 text-primary"
+                        return (
+                          <div key={metric.label} className="border rounded-lg p-4 space-y-2">
+                            <div className={`inline-flex items-center gap-2 rounded-full px-2 py-1 text-xs font-medium ${accent}`}>
+                              <Icon className="h-3.5 w-3.5" />
+                              {metric.label}
+                            </div>
+                            <div className="text-2xl font-semibold">{metric.value}</div>
+                            <p className="text-xs text-muted-foreground leading-snug">{metric.description}</p>
+                          </div>
+                        )
+                      })}
+                    </div>
+
+                    <Separator />
+
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">Рекомендации</h3>
+                      <ul className="space-y-2">
+                        {result.suggestions.map((suggestion, index) => (
+                          <li key={index} className="flex items-start gap-2 text-sm">
+                            <CheckCircle2 className="h-4 w-4 text-primary mt-0.5" />
+                            {suggestion}
+                          </li>
+                        ))}
+                      </ul>
                     </div>
                   </CardContent>
                 </Card>
 
-                {/* Detailed Analysis */}
                 <Card>
                   <CardHeader>
-                    <CardTitle>Детальный анализ</CardTitle>
+                    <CardTitle>Подробности анализа</CardTitle>
+                    <CardDescription>Показатели, рассчитанные на основе вашего текста</CardDescription>
                   </CardHeader>
-                  <CardContent>
-                    <Tabs defaultValue="grammar" className="w-full">
-                      <TabsList className="grid w-full grid-cols-4">
-                        <TabsTrigger value="grammar">Грамматика</TabsTrigger>
-                        <TabsTrigger value="style">Стиль</TabsTrigger>
-                        <TabsTrigger value="seo">SEO</TabsTrigger>
-                        <TabsTrigger value="stats">Статистика</TabsTrigger>
-                      </TabsList>
-
-                      <TabsContent value="grammar" className="space-y-4">
-                        <div className="flex items-center gap-2 mb-4">
-                          <CheckCircle className="h-5 w-5 text-green-600" />
-                          <span className="font-medium">Найдено {analysisResult.grammar.issues.length} проблем</span>
-                        </div>
-                        {analysisResult.grammar.issues.map((issue, index) => (
-                          <Alert key={index}>
-                            <AlertTriangle className="h-4 w-4" />
-                            <AlertDescription>
-                              <div className="font-medium">{issue.message}</div>
-                              <div className="text-sm text-muted-foreground mt-1">{issue.suggestion}</div>
-                            </AlertDescription>
-                          </Alert>
-                        ))}
-                      </TabsContent>
-
-                      <TabsContent value="style" className="space-y-4">
-                        <div className="grid grid-cols-2 gap-4 mb-4">
-                          <div>
-                            <div className="text-sm text-muted-foreground">Читабельность</div>
-                            <div className="text-2xl font-bold">{analysisResult.style.readability}%</div>
-                          </div>
-                          <div>
-                            <div className="text-sm text-muted-foreground">Тон</div>
-                            <div className="text-lg font-medium">{analysisResult.style.tone}</div>
-                          </div>
-                        </div>
-                        <div>
-                          <h4 className="font-medium mb-2">Рекомендации по улучшению:</h4>
-                          <ul className="space-y-2">
-                            {analysisResult.style.suggestions.map((suggestion, index) => (
-                              <li key={index} className="flex items-start gap-2 text-sm">
-                                <div className="w-1.5 h-1.5 bg-accent rounded-full mt-2 flex-shrink-0"></div>
-                                {suggestion}
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      </TabsContent>
-
-                      <TabsContent value="seo" className="space-y-4">
-                        <div>
-                          <h4 className="font-medium mb-2">Ключевые слова:</h4>
-                          <div className="flex flex-wrap gap-2 mb-4">
-                            {analysisResult.seo.keywords.map((keyword, index) => (
-                              <Badge key={index} variant="outline">
-                                {keyword}
-                              </Badge>
-                            ))}
-                          </div>
-                        </div>
-                        <div>
-                          <h4 className="font-medium mb-2">Рекомендации:</h4>
-                          <ul className="space-y-2">
-                            {analysisResult.seo.recommendations.map((rec, index) => (
-                              <li key={index} className="flex items-start gap-2 text-sm">
-                                <div className="w-1.5 h-1.5 bg-accent rounded-full mt-2 flex-shrink-0"></div>
-                                {rec}
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      </TabsContent>
-
-                      <TabsContent value="stats" className="space-y-4">
-                        <div className="grid grid-cols-2 gap-4">
-                          <div className="flex items-center gap-3">
-                            <div className="p-2 bg-primary/10 rounded-lg">
-                              <FileText className="h-4 w-4 text-primary" />
-                            </div>
-                            <div>
-                              <div className="text-2xl font-bold">{analysisResult.stats.words}</div>
-                              <div className="text-sm text-muted-foreground">Слов</div>
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <div className="p-2 bg-accent/10 rounded-lg">
-                              <BookOpen className="h-4 w-4 text-accent" />
-                            </div>
-                            <div>
-                              <div className="text-2xl font-bold">{analysisResult.stats.sentences}</div>
-                              <div className="text-sm text-muted-foreground">Предложений</div>
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <div className="p-2 bg-primary/10 rounded-lg">
-                              <Users className="h-4 w-4 text-primary" />
-                            </div>
-                            <div>
-                              <div className="text-2xl font-bold">{analysisResult.stats.characters}</div>
-                              <div className="text-sm text-muted-foreground">Символов</div>
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <div className="p-2 bg-accent/10 rounded-lg">
-                              <Zap className="h-4 w-4 text-accent" />
-                            </div>
-                            <div>
-                              <div className="text-2xl font-bold">{analysisResult.stats.readingTime}</div>
-                              <div className="text-sm text-muted-foreground">Мин чтения</div>
-                            </div>
-                          </div>
-                        </div>
-                      </TabsContent>
-                    </Tabs>
-                  </CardContent>
-                </Card>
-
-                {/* Actions */}
-                <Card>
-                  <CardContent className="pt-6">
-                    <div className="flex items-center justify-between">
-                      <div className="text-sm text-muted-foreground">
-                        Анализ завершен • Найдено {analysisResult.grammar.issues.length} проблем
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Button variant="outline" size="sm">
-                          <Save className="h-4 w-4 mr-2" />
-                          Сохранить изменения
-                        </Button>
-                        <Button size="sm" onClick={handleAnalyze}>
-                          <RefreshCw className="h-4 w-4 mr-2" />
-                          Переписать текст
-                        </Button>
-                      </div>
+                  <CardContent className="space-y-4 text-sm text-muted-foreground">
+                    <div className="flex items-center gap-2">
+                      <Brain className="h-4 w-4 text-primary" />
+                      <span>
+                        Индекс читаемости: <strong>{Math.round(result.metrics.readability)}</strong>. Значение от 12 до 20 считается комфортным
+                        для большинства читателей.
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <AlertTriangle className="h-4 w-4 text-accent" />
+                      <span>
+                        Длина предложений: в среднем {Math.round(result.metrics.wordCount / Math.max(1, result.metrics.sentenceCount))} слов. Постарайтесь
+                        избегать слишком длинных конструкций.
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <CheckCircle2 className="h-4 w-4 text-primary" />
+                      <span>
+                        Словарное разнообразие: {result.metrics.uniqueWords} уникальных слов. Это {Math.round((result.metrics.uniqueWords /
+                        Math.max(1, result.metrics.wordCount)) * 100)}% от общего количества.
+                      </span>
                     </div>
                   </CardContent>
                 </Card>
               </>
             ) : (
-              <Card className="border-dashed">
-                <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-                  <div className="p-4 bg-muted rounded-full mb-4">
-                    <Target className="h-8 w-8 text-muted-foreground" />
-                  </div>
-                  <h3 className="text-lg font-semibold mb-2">Готовы проанализировать текст?</h3>
-                  <p className="text-muted-foreground mb-4 max-w-sm">
-                    Вставьте текст в поле слева и нажмите "Проанализировать" для получения детального анализа
+              <Card>
+                <CardHeader>
+                  <CardTitle>Результаты появятся здесь</CardTitle>
+                  <CardDescription>Запустите анализ, чтобы получить отчёт и рекомендации</CardDescription>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground space-y-3">
+                  <p>
+                    Мы измерим объём текста, оценим читаемость и предложим улучшения. Используйте инструмент перед публикацией материалов.
                   </p>
-                  <Badge variant="secondary">
-                    <Target className="h-3 w-3 mr-1" />
-                    AI-анализ
-                  </Badge>
+                  <p>
+                    Рекомендации формируются мгновенно — вы сможете увидеть сильные стороны текста и области для доработки.
+                  </p>
                 </CardContent>
               </Card>
             )}

--- a/components/providers/auth-context.tsx
+++ b/components/providers/auth-context.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { createContext, useContext, useMemo } from "react"
+import { useAuth, type AuthUser } from "@/hooks/use-auth"
+
+type AuthContextValue = {
+  user: AuthUser | null
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+  setUser: (user: AuthUser | null) => void
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const { user, loading, error, refresh, setUser } = useAuth()
+
+  const value = useMemo(
+    () => ({
+      user,
+      loading,
+      error,
+      refresh,
+      setUser,
+    }),
+    [user, loading, error, refresh, setUser],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuthContext() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuthContext должен использоваться внутри AuthProvider")
+  }
+  return context
+}

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -1,0 +1,39 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { apiClient } from "@/lib/api-client"
+
+export type AuthUser = {
+  id: string
+  email: string
+  name: string
+  subscriptionPlan: string
+  subscriptionExpiresAt?: string | null
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = async () => {
+    setLoading(true)
+    try {
+      const { user } = await apiClient.currentUser()
+      setUser(user)
+      setError(null)
+    } catch (error) {
+      setUser(null)
+      setError((error as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { user, loading, error, refresh, setUser }
+}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,0 +1,67 @@
+export type ApiError = {
+  error: string
+}
+
+async function apiFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    credentials: "include",
+  })
+
+  const data = await response.json().catch(() => undefined)
+  if (!response.ok) {
+    const message = (data as ApiError | undefined)?.error ?? "Не удалось выполнить запрос"
+    throw new Error(message)
+  }
+  return data as T
+}
+
+export const apiClient = {
+  register: (payload: { name: string; email: string; password: string }) =>
+    apiFetch<{ user: unknown }>("/api/auth/register", { method: "POST", body: JSON.stringify(payload) }),
+  login: (payload: { email: string; password: string }) =>
+    apiFetch<{ user: unknown }>("/api/auth/login", { method: "POST", body: JSON.stringify(payload) }),
+  logout: () => apiFetch<{ success: boolean }>("/api/auth/logout", { method: "POST" }),
+  currentUser: () => apiFetch<{ user: any }>("/api/auth/me"),
+  forgotPassword: (payload: { email: string }) =>
+    apiFetch<{ success: boolean; resetToken?: string }>("/api/auth/forgot-password", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  resetPassword: (payload: { token: string; password: string }) =>
+    apiFetch<{ success: boolean }>("/api/auth/reset-password", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  generateContent: (payload: Record<string, unknown>) =>
+    apiFetch<{ content: string }>("/api/ai/content/generate", { method: "POST", body: JSON.stringify(payload) }),
+  analyzeText: (payload: Record<string, unknown>) =>
+    apiFetch<{ metrics: any; suggestions: string[] }>("/api/ai/text/analyze", { method: "POST", body: JSON.stringify(payload) }),
+  chatMessage: (payload: { message: string }) =>
+    apiFetch<{ messages: any[] }>("/api/ai/chat/message", { method: "POST", body: JSON.stringify(payload) }),
+  generateImage: (payload: Record<string, unknown>) =>
+    apiFetch<{ images: { id: string; url: string }[] }>("/api/ai/image/generate", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  transcribeAudio: (payload: { audio: string }) =>
+    apiFetch<{ transcript: string }>("/api/ai/voice/transcribe", { method: "POST", body: JSON.stringify(payload) }),
+  marketingIdea: (payload: Record<string, unknown>) =>
+    apiFetch<{ idea: any; history: any[] }>("/api/ai/marketing/ideas", { method: "POST", body: JSON.stringify(payload) }),
+  listProjects: () => apiFetch<{ projects: any[] }>("/api/projects"),
+  createProject: (payload: Record<string, unknown>) =>
+    apiFetch<{ project: any }>("/api/projects", { method: "POST", body: JSON.stringify(payload) }),
+  dashboard: () => apiFetch<{ snapshot: any; projects: any[]; requests: any[] }>("/api/dashboard"),
+  uploadFile: (payload: { filename: string; mimeType: string; content: string; originalName?: string }) =>
+    apiFetch<{ file: any }>("/api/files/upload", { method: "POST", body: JSON.stringify(payload) }),
+  updateProfile: (payload: Record<string, unknown>) =>
+    apiFetch<{ user: any }>("/api/users/profile", { method: "PUT", body: JSON.stringify(payload) }),
+  listModels: () => apiFetch<{ models: any[] }>("/api/ai/models"),
+  addModel: (payload: Record<string, unknown>) =>
+    apiFetch<{ model: any }>("/api/ai/models", { method: "POST", body: JSON.stringify(payload) }),
+  deleteModel: (id: string) => apiFetch<{ success: boolean }>(`/api/ai/models/${id}`, { method: "DELETE" }),
+}

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -1,0 +1,66 @@
+import { cookies } from "next/headers"
+import { NextRequest } from "next/server"
+import {
+  createSession,
+  deleteSession,
+  findUserByEmail,
+  getSession,
+  getUserById,
+  verifyPassword,
+} from "./database"
+
+const SESSION_COOKIE = "ai-helper-session"
+
+export function requireAuth(request: NextRequest) {
+  const token = request.cookies.get(SESSION_COOKIE)?.value
+  const session = getSession(token)
+  if (!session) {
+    throw new Error("UNAUTHORIZED")
+  }
+  const user = getUserById(session.userId)
+  if (!user) {
+    throw new Error("UNAUTHORIZED")
+  }
+  return user
+}
+
+export function readUserFromCookies(): ReturnType<typeof getUserById> {
+  const store = cookies()
+  const token = store.get(SESSION_COOKIE)?.value
+  const session = getSession(token)
+  if (!session) return undefined
+  return getUserById(session.userId)
+}
+
+export function createLoginSession(userId: string) {
+  const session = createSession(userId)
+  const store = cookies()
+  store.set(SESSION_COOKIE, session.token, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  })
+  return session
+}
+
+export function clearLoginSession() {
+  const store = cookies()
+  const token = store.get(SESSION_COOKIE)?.value
+  if (token) {
+    deleteSession(token)
+    store.delete(SESSION_COOKIE)
+  }
+}
+
+export function authenticateWithCredentials(email: string, password: string) {
+  const user = findUserByEmail(email)
+  if (!user) return undefined
+  const isValid = verifyPassword(password, user.passwordHash)
+  if (!isValid) return undefined
+  return user
+}
+
+export function getSessionToken(): string | undefined {
+  return cookies().get(SESSION_COOKIE)?.value
+}

--- a/lib/server/database.ts
+++ b/lib/server/database.ts
@@ -1,0 +1,535 @@
+import { randomUUID, createHash } from "crypto"
+
+type Role = "user" | "admin"
+
+type User = {
+  id: string
+  email: string
+  passwordHash: string
+  name: string
+  avatarUrl?: string
+  subscriptionPlan: string
+  subscriptionExpiresAt?: string | null
+  createdAt: string
+  updatedAt: string
+  role: Role
+}
+
+type Session = {
+  token: string
+  userId: string
+  createdAt: string
+}
+
+type Project = {
+  id: string
+  userId: string
+  name: string
+  description?: string
+  type: string
+  settings: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+}
+
+type AIRequest = {
+  id: string
+  userId: string
+  projectId?: string
+  type: string
+  inputData: Record<string, unknown>
+  outputData?: Record<string, unknown>
+  modelUsed?: string
+  tokensUsed?: number
+  cost?: number
+  status: "pending" | "completed" | "failed"
+  errorMessage?: string
+  createdAt: string
+}
+
+type FileRecord = {
+  id: string
+  userId: string
+  filename: string
+  originalName: string
+  mimeType: string
+  sizeBytes: number
+  storagePath: string
+  createdAt: string
+}
+
+type Subscription = {
+  id: string
+  userId: string
+  planName: string
+  status: "active" | "cancelled" | "expired"
+  currentPeriodStart: string
+  currentPeriodEnd: string
+  createdAt: string
+}
+
+type UsageLimit = {
+  id: string
+  userId: string
+  periodStart: string
+  periodEnd: string
+  requestsUsed: number
+  requestsLimit: number
+  tokensUsed: number
+  tokensLimit: number
+}
+
+type ResetToken = {
+  token: string
+  userId: string
+  expiresAt: string
+}
+
+type AIModel = {
+  id: string
+  userId: string
+  provider: string
+  modelName: string
+  apiKey?: string
+  endpointUrl?: string
+  parameters: Record<string, unknown>
+  isActive: boolean
+  createdAt: string
+}
+
+type ChatMessage = {
+  id: string
+  userId: string
+  role: "user" | "assistant"
+  content: string
+  createdAt: string
+}
+
+type MarketingIdea = {
+  id: string
+  userId: string
+  topic: string
+  channel: string
+  idea: string
+  createdAt: string
+}
+
+type DashboardSnapshot = {
+  projects: number
+  contentGenerated: number
+  textAnalyzed: number
+  chatMessages: number
+  marketingIdeas: number
+  usage: UsageLimit
+  lastUpdated: string
+}
+
+type DatabaseState = {
+  users: Map<string, User>
+  sessions: Map<string, Session>
+  projects: Map<string, Project>
+  aiRequests: Map<string, AIRequest>
+  files: Map<string, FileRecord>
+  subscriptions: Map<string, Subscription>
+  usageLimits: Map<string, UsageLimit>
+  resetTokens: Map<string, ResetToken>
+  aiModels: Map<string, AIModel>
+  chatMessages: Map<string, ChatMessage[]>
+  marketingIdeas: Map<string, MarketingIdea[]>
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __inMemoryDb: DatabaseState | undefined
+}
+
+function createInitialState(): DatabaseState {
+  const now = new Date().toISOString()
+  const defaultUserId = randomUUID()
+  const subscription: Subscription = {
+    id: randomUUID(),
+    userId: defaultUserId,
+    planName: "pro",
+    status: "active",
+    currentPeriodStart: now,
+    currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: now,
+  }
+
+  const usage: UsageLimit = {
+    id: randomUUID(),
+    userId: defaultUserId,
+    periodStart: now,
+    periodEnd: subscription.currentPeriodEnd,
+    requestsUsed: 0,
+    requestsLimit: 1000,
+    tokensUsed: 0,
+    tokensLimit: 500000,
+  }
+
+  const defaultUser: User = {
+    id: defaultUserId,
+    email: "demo@aihelper.dev",
+    passwordHash: hashPassword("demo1234"),
+    name: "Demo User",
+    avatarUrl: undefined,
+    subscriptionPlan: "pro",
+    subscriptionExpiresAt: subscription.currentPeriodEnd,
+    createdAt: now,
+    updatedAt: now,
+    role: "user",
+  }
+
+  return {
+    users: new Map([[defaultUser.id, defaultUser]]),
+    sessions: new Map(),
+    projects: new Map(),
+    aiRequests: new Map(),
+    files: new Map(),
+    subscriptions: new Map([[subscription.id, subscription]]),
+    usageLimits: new Map([[usage.id, usage]]),
+    resetTokens: new Map(),
+    aiModels: new Map(),
+    chatMessages: new Map([[defaultUser.id, []]]),
+    marketingIdeas: new Map([[defaultUser.id, []]]),
+  }
+}
+
+export const db: DatabaseState = global.__inMemoryDb ?? createInitialState()
+
+if (!global.__inMemoryDb) {
+  global.__inMemoryDb = db
+}
+
+export function hashPassword(password: string): string {
+  return createHash("sha256").update(password).digest("hex")
+}
+
+export function verifyPassword(password: string, hash: string): boolean {
+  return hashPassword(password) === hash
+}
+
+export function createUser(params: { email: string; password: string; name: string }): User {
+  const now = new Date().toISOString()
+  const id = randomUUID()
+  const user: User = {
+    id,
+    email: params.email.toLowerCase(),
+    passwordHash: hashPassword(params.password),
+    name: params.name,
+    subscriptionPlan: "free",
+    subscriptionExpiresAt: null,
+    createdAt: now,
+    updatedAt: now,
+    role: "user",
+  }
+  db.users.set(id, user)
+
+  const usage: UsageLimit = {
+    id: randomUUID(),
+    userId: id,
+    periodStart: now,
+    periodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    requestsUsed: 0,
+    requestsLimit: 500,
+    tokensUsed: 0,
+    tokensLimit: 250000,
+  }
+  db.usageLimits.set(usage.id, usage)
+
+  return user
+}
+
+export function findUserByEmail(email: string): User | undefined {
+  const lower = email.toLowerCase()
+  for (const user of db.users.values()) {
+    if (user.email === lower) {
+      return user
+    }
+  }
+  return undefined
+}
+
+export function getUserById(id: string): User | undefined {
+  return db.users.get(id)
+}
+
+export function updateUser(id: string, updates: Partial<Omit<User, "id" | "createdAt" | "passwordHash">> & { password?: string }): User | undefined {
+  const user = db.users.get(id)
+  if (!user) return undefined
+  const now = new Date().toISOString()
+  if (updates.email) {
+    user.email = updates.email.toLowerCase()
+  }
+  if (updates.name) {
+    user.name = updates.name
+  }
+  if (updates.subscriptionPlan) {
+    user.subscriptionPlan = updates.subscriptionPlan
+  }
+  if ("subscriptionExpiresAt" in updates) {
+    user.subscriptionExpiresAt = updates.subscriptionExpiresAt ?? null
+  }
+  if (updates.avatarUrl !== undefined) {
+    user.avatarUrl = updates.avatarUrl
+  }
+  if (updates.password) {
+    user.passwordHash = hashPassword(updates.password)
+  }
+  user.updatedAt = now
+  db.users.set(id, user)
+  return user
+}
+
+export function createSession(userId: string): Session {
+  const session: Session = {
+    token: randomUUID(),
+    userId,
+    createdAt: new Date().toISOString(),
+  }
+  db.sessions.set(session.token, session)
+  return session
+}
+
+export function getSession(token: string | undefined | null): Session | undefined {
+  if (!token) return undefined
+  return db.sessions.get(token)
+}
+
+export function deleteSession(token: string): void {
+  db.sessions.delete(token)
+}
+
+export function createProject(
+  userId: string,
+  params: { name: string; description?: string; type: string; settings?: Record<string, unknown> },
+): Project {
+  const now = new Date().toISOString()
+  const project: Project = {
+    id: randomUUID(),
+    userId,
+    name: params.name,
+    description: params.description,
+    type: params.type,
+    settings: params.settings ?? {},
+    createdAt: now,
+    updatedAt: now,
+  }
+  db.projects.set(project.id, project)
+  return project
+}
+
+export function listProjects(userId: string): Project[] {
+  return [...db.projects.values()].filter((project) => project.userId === userId)
+}
+
+export function getProject(userId: string, projectId: string): Project | undefined {
+  const project = db.projects.get(projectId)
+  if (!project || project.userId !== userId) return undefined
+  return project
+}
+
+export function updateProject(
+  userId: string,
+  projectId: string,
+  updates: Partial<Omit<Project, "id" | "userId" | "createdAt">>,
+): Project | undefined {
+  const project = getProject(userId, projectId)
+  if (!project) return undefined
+  const now = new Date().toISOString()
+  Object.assign(project, updates)
+  project.updatedAt = now
+  db.projects.set(project.id, project)
+  return project
+}
+
+export function deleteProject(userId: string, projectId: string): boolean {
+  const project = getProject(userId, projectId)
+  if (!project) return false
+  return db.projects.delete(projectId)
+}
+
+export function recordAIRequest(
+  params: Omit<AIRequest, "id" | "createdAt"> & { createdAt?: string },
+): AIRequest {
+  const now = params.createdAt ?? new Date().toISOString()
+  const request: AIRequest = {
+    id: randomUUID(),
+    createdAt: now,
+    ...params,
+  }
+  db.aiRequests.set(request.id, request)
+  return request
+}
+
+export function listAIRequests(userId: string): AIRequest[] {
+  return [...db.aiRequests.values()].filter((request) => request.userId === userId)
+}
+
+export function saveFile(record: Omit<FileRecord, "id" | "createdAt">): FileRecord {
+  const file: FileRecord = {
+    id: randomUUID(),
+    createdAt: new Date().toISOString(),
+    ...record,
+  }
+  db.files.set(file.id, file)
+  return file
+}
+
+export function getFile(userId: string, fileId: string): FileRecord | undefined {
+  const file = db.files.get(fileId)
+  if (!file || file.userId !== userId) return undefined
+  return file
+}
+
+export function deleteFile(userId: string, fileId: string): boolean {
+  const file = getFile(userId, fileId)
+  if (!file) return false
+  return db.files.delete(fileId)
+}
+
+export function upsertAIModel(
+  userId: string,
+  model: Omit<AIModel, "id" | "createdAt" | "userId"> & { id?: string },
+): AIModel {
+  const now = new Date().toISOString()
+  const id = model.id ?? randomUUID()
+  const record: AIModel = {
+    id,
+    userId,
+    provider: model.provider,
+    modelName: model.modelName,
+    apiKey: model.apiKey,
+    endpointUrl: model.endpointUrl,
+    parameters: model.parameters ?? {},
+    isActive: model.isActive ?? true,
+    createdAt: db.aiModels.get(id)?.createdAt ?? now,
+  }
+  db.aiModels.set(id, record)
+  return record
+}
+
+export function listAIModels(userId: string): AIModel[] {
+  return [...db.aiModels.values()].filter((model) => model.userId === userId)
+}
+
+export function deleteAIModel(userId: string, modelId: string): boolean {
+  const model = db.aiModels.get(modelId)
+  if (!model || model.userId !== userId) return false
+  return db.aiModels.delete(modelId)
+}
+
+export function addChatMessage(
+  userId: string,
+  message: Omit<ChatMessage, "id" | "createdAt" | "userId"> & { role: "user" | "assistant" },
+): ChatMessage[] {
+  const history = db.chatMessages.get(userId) ?? []
+  const entry: ChatMessage = {
+    id: randomUUID(),
+    userId,
+    role: message.role,
+    content: message.content,
+    createdAt: new Date().toISOString(),
+  }
+  const nextHistory = [...history, entry]
+  db.chatMessages.set(userId, nextHistory)
+  return nextHistory
+}
+
+export function getChatHistory(userId: string): ChatMessage[] {
+  return db.chatMessages.get(userId) ?? []
+}
+
+export function addMarketingIdea(
+  userId: string,
+  idea: Omit<MarketingIdea, "id" | "createdAt" | "userId">,
+): MarketingIdea {
+  const entry: MarketingIdea = {
+    id: randomUUID(),
+    userId,
+    topic: idea.topic,
+    channel: idea.channel,
+    idea: idea.idea,
+    createdAt: new Date().toISOString(),
+  }
+  const ideas = db.marketingIdeas.get(userId) ?? []
+  ideas.push(entry)
+  db.marketingIdeas.set(userId, ideas)
+  return entry
+}
+
+export function listMarketingIdeas(userId: string): MarketingIdea[] {
+  return db.marketingIdeas.get(userId) ?? []
+}
+
+export function issueResetToken(userId: string): ResetToken {
+  const token: ResetToken = {
+    token: randomUUID(),
+    userId,
+    expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+  }
+  db.resetTokens.set(token.token, token)
+  return token
+}
+
+export function consumeResetToken(token: string): ResetToken | undefined {
+  const resetToken = db.resetTokens.get(token)
+  if (!resetToken) return undefined
+  if (new Date(resetToken.expiresAt).getTime() < Date.now()) {
+    db.resetTokens.delete(token)
+    return undefined
+  }
+  db.resetTokens.delete(token)
+  return resetToken
+}
+
+export function getUsageForUser(userId: string): UsageLimit {
+  let usage = [...db.usageLimits.values()].find((item) => item.userId === userId)
+  if (!usage) {
+    usage = {
+      id: randomUUID(),
+      userId,
+      periodStart: new Date().toISOString(),
+      periodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      requestsUsed: 0,
+      requestsLimit: 500,
+      tokensUsed: 0,
+      tokensLimit: 250000,
+    }
+    db.usageLimits.set(usage.id, usage)
+  }
+  return usage
+}
+
+export function incrementUsage(userId: string, tokens: number): UsageLimit {
+  const usage = getUsageForUser(userId)
+  usage.requestsUsed += 1
+  usage.tokensUsed += tokens
+  db.usageLimits.set(usage.id, usage)
+  return usage
+}
+
+export function getDashboardSnapshot(userId: string): DashboardSnapshot {
+  const usage = getUsageForUser(userId)
+  const projects = listProjects(userId).length
+  const aiRequests = listAIRequests(userId)
+  const contentGenerated = aiRequests.filter((request) => request.type === "content_generation").length
+  const textAnalyzed = aiRequests.filter((request) => request.type === "text_analysis").length
+  const chatMessages = getChatHistory(userId).length
+  const marketingIdeas = listMarketingIdeas(userId).length
+  return {
+    projects,
+    contentGenerated,
+    textAnalyzed,
+    chatMessages,
+    marketingIdeas,
+    usage,
+    lastUpdated: new Date().toISOString(),
+  }
+}
+
+export function ensureChatHistory(userId: string): void {
+  if (!db.chatMessages.has(userId)) {
+    db.chatMessages.set(userId, [])
+  }
+}


### PR DESCRIPTION
## Summary
- add in-memory backend routes covering authentication, projects, AI tools, files, and dashboard data
- wire client pages to the new API via an auth-aware provider and shared client helper
- update feature pages to consume live data, handle errors, and persist user profile changes
- document the runtime behaviour, endpoints, and quick-start instructions in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9143df5348329b8bd1fa8b265bdb6